### PR TITLE
Implement basic pipeline for a single population

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Meow 🐈
 
-Multipopulation evolutionary optimisation wiring
+Multipopulation evolutionary optimisation workbench

--- a/examples/rastrigin.ex
+++ b/examples/rastrigin.ex
@@ -1,33 +1,40 @@
+Mix.install([
+  {:exla, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "exla"},
+  {:nx, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "nx", override: true},
+  {:benchee, "~> 1.0"},
+  {:meow, path: __DIR__ |> Path.join("..") |> Path.expand()}
+])
+
 defmodule Rastrigin do
   import Nx.Defn
-
-  alias Meow.Model
-  alias Meow.Generic.{Termination}
-  alias MeowNx.{Selection, Crossover, Mutation, Initializer}
+  alias Meow.{Model, Pipeline}
+  alias Meow.Op.Termination
+  alias MeowNx.Init
+  alias MeowNx.Op.{Selection, Crossover, Mutation}
 
   def model() do
     Model.new(
-      initializer: Initializer.real_random_uniform(min: -5.15, max: 5.12, n: 1000, size: 1000),
-      evaluate: &evaluate/1
+      Init.real_random_uniform(20, 100, -5.12, 5.12),
+      &evaluate/1
     )
     |> Model.add_pipeline(
       Pipeline.new([
-        Selection.tournament(n: 1000),
-        Crossover.uniform(probability: 0.5),
-        Mutation.replace_random_uniform(min: -5.12, max: 5.12, probability: 0.001),
-        Termination.max_generations(n: 10)
+        Selection.tournament(20),
+        Crossover.uniform(0.5),
+        Mutation.replace_random_uniform(0.001, -5.12, 5.12),
+        Termination.max_generations(50000)
       ])
     )
   end
 
   @defn_compiler EXLA
-  defn evaluate(population) do
+  defn evaluate(genomes) do
     sums =
-      (10 + Nx.power(population, 2) - 10 * Nx.cos(population * 2 * 3.141592653589793))
+      (10 + Nx.power(genomes, 2) - 10 * Nx.cos(genomes * 2 * 3.141592653589793))
       |> Nx.sum(axes: [1])
 
     -sums
   end
 end
 
-:timer.tc(fn -> Runner.run(Rastrigin.model()) end)
+:timer.tc(fn -> Meow.Runner.run(Rastrigin.model()) end) |> IO.inspect()

--- a/examples/rastrigin.ex
+++ b/examples/rastrigin.ex
@@ -1,0 +1,33 @@
+defmodule Rastrigin do
+  import Nx.Defn
+
+  alias Meow.Model
+  alias Meow.Generic.{Termination}
+  alias MeowNx.{Selection, Crossover, Mutation, Initializer}
+
+  def model() do
+    Model.new(
+      initializer: Initializer.real_random_uniform(min: -5.15, max: 5.12, n: 1000, size: 1000),
+      evaluate: &evaluate/1
+    )
+    |> Model.add_pipeline(
+      Pipeline.new([
+        Selection.tournament(n: 1000),
+        Crossover.uniform(probability: 0.5),
+        Mutation.replace_random_uniform(min: -5.12, max: 5.12, probability: 0.001),
+        Termination.max_generations(n: 10)
+      ])
+    )
+  end
+
+  @defn_compiler EXLA
+  defn evaluate(population) do
+    sums =
+      (10 + Nx.power(population, 2) - 10 * Nx.cos(population * 2 * 3.141592653589793))
+      |> Nx.sum(axes: [1])
+
+    -sums
+  end
+end
+
+:timer.tc(fn -> Runner.run(Rastrigin.model()) end)

--- a/examples/rastrigin.ex
+++ b/examples/rastrigin.ex
@@ -27,10 +27,12 @@ defmodule Rastrigin do
     )
   end
 
+  @two_pi 2 * :math.pi()
+
   @defn_compiler EXLA
   defn evaluate(genomes) do
     sums =
-      (10 + Nx.power(genomes, 2) - 10 * Nx.cos(genomes * 2 * 3.141592653589793))
+      (10 + Nx.power(genomes, 2) - 10 * Nx.cos(genomes * @two_pi))
       |> Nx.sum(axes: [1])
 
     -sums

--- a/lib/meow/model.ex
+++ b/lib/meow/model.ex
@@ -1,0 +1,11 @@
+defmodule Meow.Model do
+  defstruct [:initializer, :evaluate, pipelines: []]
+
+  def new(initializer, evaluate) do
+    %__MODULE__{initializer: initializer, evaluate: evaluate}
+  end
+
+  def add_pipeline(model, pipeline) do
+    %{model | pipelines: model.pipelines ++ [pipeline]}
+  end
+end

--- a/lib/meow/model.ex
+++ b/lib/meow/model.ex
@@ -1,10 +1,51 @@
 defmodule Meow.Model do
+  @moduledoc """
+  Definition of an evolutionary model.
+  """
+
   defstruct [:initializer, :evaluate, pipelines: []]
 
+  alias Meow.{Population, Pipeline}
+
+  @type t :: %__MODULE__{
+          initializer: initializer(),
+          evaluate: evaluate(),
+          pipelines: list(Pipeline.t())
+        }
+
+  @typedoc """
+  A function used to generate an initial genomes term
+  according to the chosen representation.
+  """
+  @type initializer :: (() -> Population.genomes())
+
+  @typedoc """
+  A function used to calculate the assessment of all
+  individual genomes in a population.
+
+  Essentially, this is the optimisation objective,
+  except the calculation is supposed to work on a batch
+  of genomes. Note that higher values should indicate
+  a better solution (individual), hence the evolutionary
+  process is going to try maximising this function.
+  """
+  @type evaluate :: (Population.genomes() -> Population.fitness())
+
+  @doc """
+  Entrypoint for building a new model definition.
+  """
+  @spec new(initializer(), evaluate()) :: t()
   def new(initializer, evaluate) do
     %__MODULE__{initializer: initializer, evaluate: evaluate}
   end
 
+  @doc """
+  Adds an evolutionary pipeline to the model definition.
+
+  Each pipeline defines how a single population evolves,
+  so multiple pipelines imply multi-population model.
+  """
+  @spec add_pipeline(t(), Pipeline.t()) :: t()
   def add_pipeline(model, pipeline) do
     %{model | pipelines: model.pipelines ++ [pipeline]}
   end

--- a/lib/meow/op.ex
+++ b/lib/meow/op.ex
@@ -3,16 +3,49 @@ defmodule Meow.Op do
 
   defstruct [:name, :impl, :requires_fitness, :invalidates_fitness]
 
+  alias Meow.Population
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          impl: (Population.t() -> Population.t()),
+          requires_fitness: boolean(),
+          invalidates_fitness: boolean()
+        }
+
+  @doc """
+  Applies `operation` to `population` and returns
+  a new transformed population.
+  """
+  @spec apply(Population.t(), t()) :: Population.t()
+  def apply(population, operation)
+
+  def apply(%{fitness: nil}, %{requires_fitness: true}) do
+    raise ArgumentError, "operation requires fitness, but it has not been computed"
+  end
+
   def apply(population, operation) do
     operation.impl.(population)
   end
 
   # Helpers to use when building custom operations
 
+  @doc """
+  Updates population genomes with the given function.
+  """
+  @spec map_genomes(Population.t(), (Population.genomes() -> Population.genomes())) ::
+          Population.t()
   def map_genomes(population, fun) do
     update_in(population.genomes, fun)
   end
 
+  @doc """
+  Updates both population genomes and fitness with the given function.
+  """
+  @spec map_genomes_and_fitness(
+          Population.t(),
+          (Population.genomes(), Population.fitness() ->
+             {Population.genomes(), Population.fitness()})
+        ) :: Population.t()
   def map_genomes_and_fitness(population, fun) do
     {genomes, fitness} = fun.(population.genomes, population.fitness)
     %{population | genomes: genomes, fitness: fitness}

--- a/lib/meow/op.ex
+++ b/lib/meow/op.ex
@@ -1,0 +1,20 @@
+defmodule Meow.Op do
+  @enforce_keys [:name, :impl, :requires_fitness, :invalidates_fitness]
+
+  defstruct [:name, :impl, :requires_fitness, :invalidates_fitness]
+
+  def apply(population, operation) do
+    operation.impl.(population)
+  end
+
+  # Helpers to use when building custom operations
+
+  def map_genomes(population, fun) do
+    update_in(population.genomes, fun)
+  end
+
+  def map_genomes_and_fitness(population, fun) do
+    {genomes, fitness} = fun.(population.genomes, population.fitness)
+    %{population | genomes: genomes, fitness: fitness}
+  end
+end

--- a/lib/meow/op/termination.ex
+++ b/lib/meow/op/termination.ex
@@ -1,0 +1,18 @@
+defmodule Meow.Op.Termination do
+  alias Meow.Op
+
+  def max_generations(n) do
+    %Op{
+      name: "Termination max populations",
+      requires_fitness: false,
+      invalidates_fitness: false,
+      impl: fn population ->
+        if population.generation >= n do
+          %{population | terminated: true}
+        else
+          population
+        end
+      end
+    }
+  end
+end

--- a/lib/meow/op/termination.ex
+++ b/lib/meow/op/termination.ex
@@ -3,7 +3,7 @@ defmodule Meow.Op.Termination do
 
   def max_generations(n) do
     %Op{
-      name: "Termination max populations",
+      name: "Termination: max generations",
       requires_fitness: false,
       invalidates_fitness: false,
       impl: fn population ->

--- a/lib/meow/pipeline.ex
+++ b/lib/meow/pipeline.ex
@@ -31,7 +31,7 @@ defmodule Meow.Pipeline do
 
   The result is a new transformed population.
   The `evaluate` function is used as necessary
-  to ensure fitness is computed as needed.
+  to ensure fitness is computed if needed.
   """
   @spec apply(Population.t(), t(), Model.evaluate()) :: Population.t()
   def apply(population, pipeline, evaluate) do

--- a/lib/meow/pipeline.ex
+++ b/lib/meow/pipeline.ex
@@ -1,0 +1,37 @@
+defmodule Meow.Pipeline do
+  defstruct [:ops]
+
+  alias Meow.Op
+
+  def new(ops) do
+    %__MODULE__{ops: ops}
+  end
+
+  def apply(population, pipeline, evaluate) do
+    do_apply(population, pipeline.ops, evaluate)
+  end
+
+  defp do_apply(%{terminated: true} = population, _ops, _evaluate), do: population
+  defp do_apply(population, [], _evaluate), do: population
+
+  defp do_apply(population, [op | ops], evaluate) do
+    population
+    |> before_op_apply(op, evaluate)
+    |> Op.apply(op)
+    |> after_op_apply(op, evaluate)
+    |> do_apply(ops, evaluate)
+  end
+
+  defp before_op_apply(%{fitness: nil} = population, %{requires_fitness: true}, evaluate) do
+    fitness = evaluate.(population.genomes)
+    %{population | fitness: fitness}
+  end
+
+  defp before_op_apply(population, _op, _evaluate), do: population
+
+  defp after_op_apply(population, %{invalidates_fitness: true}, _evaluate) do
+    %{population | fitness: nil}
+  end
+
+  defp after_op_apply(population, _op, _evaluate), do: population
+end

--- a/lib/meow/pipeline.ex
+++ b/lib/meow/pipeline.ex
@@ -1,12 +1,39 @@
 defmodule Meow.Pipeline do
+  @moduledoc """
+  Definition of en evolutionary pipeline.
+
+  A single pipeline represents a sequence of steps
+  that a single population goes through in the given
+  evolutionary algorithm. Each step is of type `Meow.Op`
+  and transforms the population. Consequently the pipeline
+  takes a population in and produces a transformed
+  population out.
+  """
+
   defstruct [:ops]
 
-  alias Meow.Op
+  alias Meow.{Op, Population, Model}
 
+  @type t :: %__MODULE__{
+          ops: list(Op.t())
+        }
+
+  @doc """
+  Builds a new pipeline from a list of operations.
+  """
+  @spec new(list(Op.t())) :: t()
   def new(ops) do
     %__MODULE__{ops: ops}
   end
 
+  @doc """
+  Pipes `population` through `pipeline`.
+
+  The result is a new transformed population.
+  The `evaluate` function is used as necessary
+  to ensure fitness is computed as needed.
+  """
+  @spec apply(Population.t(), t(), Model.evaluate()) :: Population.t()
   def apply(population, pipeline, evaluate) do
     do_apply(population, pipeline.ops, evaluate)
   end

--- a/lib/meow/population.ex
+++ b/lib/meow/population.ex
@@ -1,3 +1,35 @@
 defmodule Meow.Population do
+  @moduledoc """
+  Represents a group of individuals that evolve over time.
+
+  This struct can be thought of as evolution snapshot at specific
+  point in time. It contains the list of currently living individuals
+  as well as information about the evolution progress.
+  """
+
   defstruct [:genomes, :fitness, generation: 0, terminated: false]
+
+  @typedoc """
+  The underlying representation of the population.
+
+  This should be a group of genomes, each encoding
+  an individual (solution). There is no constraint
+  on the actual type, so this could be a list,
+  a tensor, or even an arbitrary binary.
+
+  Keep in mind that depending on the representation
+  chosen, you will need to use suitable evolutionary
+  operations that work on the given type.
+  """
+  @type genomes :: any()
+
+  @typedoc """
+  The underlying representation of population's fitness.
+
+  This represents a group of fitness values,
+  each corresponding to one individual in the population.
+  Similarly to `genomes` the actual type is not enforced,
+  as long as it is compatible with the operations used.
+  """
+  @type fitness :: any()
 end

--- a/lib/meow/population.ex
+++ b/lib/meow/population.ex
@@ -1,0 +1,3 @@
+defmodule Meow.Population do
+  defstruct [:genomes, :fitness, generation: 0, terminated: false]
+end

--- a/lib/meow/runner.ex
+++ b/lib/meow/runner.ex
@@ -1,6 +1,16 @@
 defmodule Meow.Runner do
-  alias Meow.{Population, Pipeline}
+  @moduledoc """
+  A module responsible for running an evolutionary
+  algorithm, as defined by  `Meow.Model`.
+  """
 
+  alias Meow.{Population, Pipeline, Model}
+
+  @doc """
+  Iteratively transforms the population according to
+  the given model until the population is terminated.
+  """
+  @spec run(Model.t()) :: Population.t()
   def run(model) do
     genomes = model.initializer.()
     population = %Population{genomes: genomes, fitness: nil, generation: 1}

--- a/lib/meow/runner.ex
+++ b/lib/meow/runner.ex
@@ -1,7 +1,7 @@
 defmodule Meow.Runner do
   @moduledoc """
   A module responsible for running an evolutionary
-  algorithm, as defined by  `Meow.Model`.
+  algorithm, as defined by `Meow.Model`.
   """
 
   alias Meow.{Population, Pipeline, Model}

--- a/lib/meow/runner.ex
+++ b/lib/meow/runner.ex
@@ -1,0 +1,25 @@
+defmodule Meow.Runner do
+  alias Meow.{Population, Pipeline}
+
+  def run(model) do
+    genomes = model.initializer.()
+    population = %Population{genomes: genomes, fitness: nil, generation: 1}
+
+    # TODO: support multiple pipelines (populations)
+    [pipeline] = model.pipelines
+
+    run_population(population, pipeline, model)
+  end
+
+  defp run_population(population, pipeline, model) do
+    population = Pipeline.apply(population, pipeline, model.evaluate)
+
+    if population.terminated do
+      population
+    else
+      population
+      |> Map.update!(:generation, &(&1 + 1))
+      |> run_population(pipeline, model)
+    end
+  end
+end

--- a/lib/meow_nx/init.ex
+++ b/lib/meow_nx/init.ex
@@ -1,0 +1,19 @@
+defmodule MeowNx.Init do
+  import Nx.Defn
+
+  def real_random_uniform(n, length, min, max) do
+    fn ->
+      real_random_uniform_impl(n: n, length: length, min: min, max: max)
+    end
+  end
+
+  defn real_random_uniform_impl(opts \\ []) do
+    opts = keyword!(opts, [:n, :length, :min, :max])
+    n = opts[:n]
+    length = opts[:length]
+    min = opts[:min]
+    max = opts[:max]
+
+    Nx.random_uniform({n, length}, min, max)
+  end
+end

--- a/lib/meow_nx/op/crossover.ex
+++ b/lib/meow_nx/op/crossover.ex
@@ -1,0 +1,35 @@
+defmodule MeowNx.Op.Crossover do
+  import Nx.Defn
+  alias Meow.Op
+
+  def uniform(probability \\ 0.5) do
+    opts = [probability: probability]
+
+    %Op{
+      name: "[Nx] Uniform crossover",
+      requires_fitness: false,
+      invalidates_fitness: true,
+      impl: fn population ->
+        Op.map_genomes(population, fn genomes ->
+          # TODO: make compiler (and generally other options)
+          # configurable globally for the model
+          Nx.Defn.jit(&uniform_impl(&1, opts), [genomes], compiler: EXLA)
+        end)
+      end
+    }
+  end
+
+  defnp uniform_impl(parents, opts \\ []) do
+    probability = opts[:probability]
+
+    {n, length} = Nx.shape(parents)
+    half_n = transform(n, &div(&1, 2))
+
+    upper_sel = Nx.random_uniform({half_n, length}) |> Nx.greater(probability)
+    lower_sel = Nx.reverse(upper_sel, axes: [0])
+    # Generate a 0/1 matrix symmetric along the first axis
+    selection = Nx.concatenate([upper_sel, lower_sel])
+
+    Nx.select(selection, parents, Nx.reverse(parents, axes: [0]))
+  end
+end

--- a/lib/meow_nx/op/mutation.ex
+++ b/lib/meow_nx/op/mutation.ex
@@ -1,0 +1,32 @@
+defmodule MeowNx.Op.Mutation do
+  import Nx.Defn
+  alias Meow.Op
+
+  def replace_random_uniform(probability, min, max) do
+    opts = [probability: probability, min: min, max: max]
+
+    %Op{
+      name: "[Nx] Mutation replace random uniform",
+      requires_fitness: false,
+      invalidates_fitness: true,
+      impl: fn population ->
+        Op.map_genomes(population, fn genomes ->
+          Nx.Defn.jit(&replace_random_uniform_impl(&1, opts), [genomes], compiler: EXLA)
+        end)
+      end
+    }
+  end
+
+  defnp replace_random_uniform_impl(genomes, opts \\ []) do
+    probability = opts[:probability]
+    min = opts[:min]
+    max = opts[:max]
+
+    shape = Nx.shape(genomes)
+
+    # Mutate each gene separately with the given probability
+    sel = Nx.random_uniform(shape) |> Nx.less(probability)
+    new = Nx.random_uniform(shape, min, max)
+    Nx.select(sel, new, genomes)
+  end
+end

--- a/lib/meow_nx/op/selection.ex
+++ b/lib/meow_nx/op/selection.ex
@@ -1,0 +1,47 @@
+defmodule MeowNx.Op.Selection do
+  import Nx.Defn
+  alias Meow.Op
+  alias MeowNx.Utils
+
+  def tournament(n) do
+    # TODO: support percentage, something like {:fraction, 0.2}
+    opts = [n: n]
+
+    %Op{
+      name: "[Nx] Selection tournament",
+      requires_fitness: true,
+      invalidates_fitness: false,
+      impl: fn population ->
+        Op.map_genomes_and_fitness(population, fn genomes, fitness ->
+          Nx.Defn.jit(&tournament_impl(&1, &2, opts), [genomes, fitness], compiler: EXLA)
+        end)
+      end
+    }
+  end
+
+  defnp tournament_impl(genomes, fitness, opts \\ []) do
+    final_n = opts[:n]
+
+    {n, length} = Nx.shape(genomes)
+
+    # Reshape fitness into 2D, so our `gather_rows` works fine
+    fitness = Nx.reshape(fitness, {n, 1})
+
+    idx1 = Nx.random_uniform({final_n}, 0, n, type: {:u, 32})
+    idx2 = Nx.random_uniform({final_n}, 0, n, type: {:u, 32})
+
+    parents1 = Utils.gather_rows(genomes, idx1)
+    fitness1 = Utils.gather_rows(fitness, idx1)
+
+    parents2 = Utils.gather_rows(genomes, idx2)
+    fitness2 = Utils.gather_rows(fitness, idx2)
+
+    best_fitness = Nx.greater(fitness1, fitness2)
+    best_genomes = Nx.broadcast(best_fitness, {final_n, length})
+
+    fitness = Nx.select(best_fitness, fitness1, fitness2) |> Nx.reshape({final_n})
+    genomes = Nx.select(best_genomes, parents1, parents2)
+
+    {genomes, fitness}
+  end
+end

--- a/lib/meow_nx/utils.ex
+++ b/lib/meow_nx/utils.ex
@@ -1,0 +1,19 @@
+defmodule MeowNx.Utils do
+  import Nx.Defn
+
+  # This is a hack for doing gather on 2d tensor.
+  # Hopefully gather comes along: https://github.com/elixir-nx/nx/issues/223
+  #
+  # `t` is a 2d tensor and `idx` is a 1d tensor with indices of rows
+  # to select for the new 2d tensor.
+  defn gather_rows(t, idx) do
+    # n is the number of rows in the resulting 2d tensor
+    {n} = Nx.shape(idx)
+    {:u, _} = Nx.type(idx)
+    {x, _y} = Nx.shape(t)
+
+    # Each row is a one-hot encoding of which row from `t` to choose
+    selector = Nx.equal(Nx.reshape(idx, {n, 1}), Nx.iota({1, x}))
+    Nx.dot(selector, t)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -11,18 +11,15 @@ defmodule Meow.MixProject do
     ]
   end
 
-  # Run "mix help compile.app" to learn about applications.
   def application do
     [
       extra_applications: [:logger]
     ]
   end
 
-  # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+      {:nx, "~> 0.1.0-dev", github: "elixir-nx/nx", branch: "main", sparse: "nx"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,3 @@
+%{
+  "nx": {:git, "https://github.com/elixir-nx/nx.git", "4d3de03e71f091c34f6e1482fa528efbc6d2d9af", [branch: "main", sparse: "nx"]},
+}


### PR DESCRIPTION
This provides an initial setup for running an evolutionary algorithm defined by a pipeline. The new `example/rastrigin.exs` was the primary driver for this implementation.

On a high-level, we currently have a `Model` that consists of a number of `Pipelines` (although the current implementation works on a just single pipeline). Each pipeline has a number of `Op` (evolutionary operations/steps) that represent a population transform. Then a basic `Runner` is responsible for iteratively applying the given `model` to a `population`.

As for the operations, we are going to focus on `Nx`, but to separate the tensor representation from the core modules, I namespaced all the `Nx` related stuff under `MeowNx` (think of it like an integration between Meow and Nx). In the `example/rastrigin.exs` you can see how we take some modules from the `Meow` core and some modules from the `MeowNx` integration.

Some modules/functions are missing documentation, but things are gonna flux, so I just documented the core modules to outlined the idea.

*Note: I removed the initial exploration we had directly on master, so that this diff is more readable.*