### PR TITLE
Implement split merge and if control flow structures

### DIFF
--- a/lib/meow/op.ex
+++ b/lib/meow/op.ex
@@ -3,28 +3,30 @@ defmodule Meow.Op do
 
   defstruct [:name, :impl, :requires_fitness, :invalidates_fitness]
 
-  alias Meow.Population
+  alias Meow.{Population, Model}
 
   @type t :: %__MODULE__{
           name: String.t(),
-          impl: (Population.t() -> Population.t()),
+          impl: (Population.t(), context() -> Population.t()),
           requires_fitness: boolean(),
           invalidates_fitness: boolean()
         }
+
+  @type context :: %{evaluate: Model.evaluate()}
 
   @doc """
   Applies `operation` to `population` and returns
   a new transformed population.
   """
-  @spec apply(Population.t(), t()) :: Population.t()
-  def apply(population, operation)
+  @spec apply(Population.t(), t(), context()) :: Population.t()
+  def apply(population, operation, ctx)
 
-  def apply(%{fitness: nil}, %{requires_fitness: true}) do
+  def apply(%{fitness: nil}, %{requires_fitness: true}, _ctx) do
     raise ArgumentError, "operation requires fitness, but it has not been computed"
   end
 
-  def apply(population, operation) do
-    operation.impl.(population)
+  def apply(population, operation, ctx) do
+    operation.impl.(population, ctx)
   end
 
   # Helpers to use when building custom operations

--- a/lib/meow/op/flow.ex
+++ b/lib/meow/op/flow.ex
@@ -1,0 +1,38 @@
+defmodule Meow.Op.Flow do
+  alias Meow.{Op, Pipeline}
+
+  def split_merge(split_fun, pipelines, merge_fun) do
+    requires_fitness = Enum.any?(pipelines, fn %{ops: [op | _]} -> op.requires_fitness end)
+
+    %Op{
+      name: "Flow: split merge",
+      # This operation itself doesn't require fitness,
+      # but if any pipeline does, then we eagerly do so as well.
+      requires_fitness: requires_fitness,
+      # This operation itself doesn't invalidate fitness,
+      # it just merges results of the underlying pipelines.
+      invalidates_fitness: false,
+      impl: fn population, ctx ->
+        population
+        |> split_fun.()
+        |> Enum.zip(pipelines)
+        |> Enum.map(fn {population, pipeline} ->
+          Pipeline.apply(population, pipeline, ctx)
+        end)
+        |> merge_fun.()
+      end
+    }
+  end
+
+  def if(pred_fun, on_true_pipeline, on_false_pipeline) do
+    %Op{
+      name: "Flow: if",
+      requires_fitness: false,
+      invalidates_fitness: false,
+      impl: fn population, ctx ->
+        pipeline = if(pred_fun.(population), do: on_true_pipeline, else: on_false_pipeline)
+        Pipeline.apply(population, pipeline, ctx)
+      end
+    }
+  end
+end

--- a/lib/meow/op/termination.ex
+++ b/lib/meow/op/termination.ex
@@ -6,7 +6,7 @@ defmodule Meow.Op.Termination do
       name: "Termination: max generations",
       requires_fitness: false,
       invalidates_fitness: false,
-      impl: fn population ->
+      impl: fn population, _ctx ->
         if population.generation >= n do
           %{population | terminated: true}
         else

--- a/lib/meow/population.ex
+++ b/lib/meow/population.ex
@@ -9,6 +9,13 @@ defmodule Meow.Population do
 
   defstruct [:genomes, :fitness, generation: 0, terminated: false]
 
+  @type t :: %__MODULE__{
+          genomes: genomes(),
+          fitness: fitness(),
+          generation: non_neg_integer(),
+          terminated: boolean()
+        }
+
   @typedoc """
   The underlying representation of the population.
 
@@ -32,4 +39,45 @@ defmodule Meow.Population do
   as long as it is compatible with the operations used.
   """
   @type fitness :: any()
+
+  @doc """
+  Returns a list of size `times` where every item is `population`.
+  """
+  @spec duplicate(t(), pos_integer()) :: list(t())
+  def duplicate(population, times) do
+    for _ <- 1..times, do: population
+  end
+
+  @doc """
+  Shortcut for `merge_with/3` when the same merge function
+  applies for both genomes and fitness.
+  """
+  @spec merge_with(list(t()), (genomes() | fitness() -> t())) :: t()
+  def merge_with(populations, merge_fun) do
+    merge_with(populations, merge_fun, merge_fun)
+  end
+
+  @doc """
+  Merges the given populations into a single population.
+
+  Uses `genomes_merge_fun` and `fitness_merge_fun` to merge
+  genomes and fitness representations respectively.
+  """
+  @spec merge_with(list(t()), (genomes() -> t()), (fitness() -> t())) :: t()
+  def merge_with(populations, genomes_merge_fun, fitness_merge_fun) do
+    %__MODULE__{
+      genomes: populations |> Enum.map(& &1.genomes) |> genomes_merge_fun.(),
+      fitness: populations |> Enum.map(& &1.fitness) |> merge_fitness(fitness_merge_fun),
+      terminated: populations |> Enum.any?(& &1.terminated),
+      generation: populations |> Enum.map(& &1.generation) |> Enum.max()
+    }
+  end
+
+  defp merge_fitness(fitness_list, merge_fun) do
+    if Enum.any?(fitness_list, &is_nil/1) do
+      nil
+    else
+      merge_fun.(fitness_list)
+    end
+  end
 end

--- a/lib/meow/runner.ex
+++ b/lib/meow/runner.ex
@@ -14,22 +14,23 @@ defmodule Meow.Runner do
   def run(model) do
     genomes = model.initializer.()
     population = %Population{genomes: genomes, fitness: nil, generation: 1}
+    ctx = %{evaluate: model.evaluate}
 
     # TODO: support multiple pipelines (populations)
     [pipeline] = model.pipelines
 
-    run_population(population, pipeline, model)
+    run_population(population, pipeline, ctx)
   end
 
-  defp run_population(population, pipeline, model) do
-    population = Pipeline.apply(population, pipeline, model.evaluate)
+  defp run_population(population, pipeline, ctx) do
+    population = Pipeline.apply(population, pipeline, ctx)
 
     if population.terminated do
       population
     else
       population
       |> Map.update!(:generation, &(&1 + 1))
-      |> run_population(pipeline, model)
+      |> run_population(pipeline, ctx)
     end
   end
 end

--- a/lib/meow_nx/op/crossover.ex
+++ b/lib/meow_nx/op/crossover.ex
@@ -9,7 +9,7 @@ defmodule MeowNx.Op.Crossover do
       name: "[Nx] Uniform crossover",
       requires_fitness: false,
       invalidates_fitness: true,
-      impl: fn population ->
+      impl: fn population, _ctx ->
         Op.map_genomes(population, fn genomes ->
           # TODO: make compiler (and generally other options)
           # configurable globally for the model

--- a/lib/meow_nx/op/mutation.ex
+++ b/lib/meow_nx/op/mutation.ex
@@ -9,7 +9,7 @@ defmodule MeowNx.Op.Mutation do
       name: "[Nx] Mutation replace random uniform",
       requires_fitness: false,
       invalidates_fitness: true,
-      impl: fn population ->
+      impl: fn population, _ctx ->
         Op.map_genomes(population, fn genomes ->
           Nx.Defn.jit(&replace_random_uniform_impl(&1, opts), [genomes], compiler: EXLA)
         end)

--- a/lib/meow_nx/op/selection.ex
+++ b/lib/meow_nx/op/selection.ex
@@ -11,7 +11,7 @@ defmodule MeowNx.Op.Selection do
       name: "[Nx] Selection tournament",
       requires_fitness: true,
       invalidates_fitness: false,
-      impl: fn population ->
+      impl: fn population, _ctx ->
         Op.map_genomes_and_fitness(population, fn genomes, fitness ->
           Nx.Defn.jit(&tournament_impl(&1, &2, opts), [genomes, fitness], compiler: EXLA)
         end)


### PR DESCRIPTION
Introduces `Meow.Op.Flow` with control flow structures for more fancy pipelines. Importantly `split_merge` can be used to create branches within the pipeline, while `if` allows for switching parts of the pipeline dynamically based on the given condition. Both of these are actually implemented as operations that take pipelines as their arguments. This means the operations are a bit coupled to model evaluation, but at this point this looks ok, we may revisit this later if we run into any limitations.