### PR TITLE
Expand on operations and docs

### DIFF
--- a/examples/rastrigin.ex
+++ b/examples/rastrigin.ex
@@ -21,7 +21,7 @@ defmodule Rastrigin do
       Pipeline.new([
         Selection.tournament(20),
         Crossover.uniform(0.5),
-        Mutation.replace_random_uniform(0.001, -5.12, 5.12),
+        Mutation.replace_uniform(0.001, -5.12, 5.12),
         Termination.max_generations(50_000)
       ])
     )
@@ -45,7 +45,7 @@ defmodule Rastrigin do
             Pipeline.new([
               Selection.tournament(16),
               Crossover.uniform(0.5),
-              Mutation.replace_random_uniform(0.001, -5.12, 5.12)
+              Mutation.replace_uniform(0.001, -5.12, 5.12)
             ])
           ],
           &Population.merge_with(&1, fn x -> Nx.concatenate(x) end)
@@ -72,7 +72,7 @@ defmodule Rastrigin do
             Crossover.uniform(0.3)
           ])
         ),
-        Mutation.replace_random_uniform(0.001, -5.12, 5.12),
+        Mutation.replace_uniform(0.001, -5.12, 5.12),
         Termination.max_generations(50_000)
       ])
     )
@@ -90,5 +90,5 @@ defmodule Rastrigin do
   end
 end
 
-model = Rastrigin.model_if()
+model = Rastrigin.model_branching()
 :timer.tc(fn -> Meow.Runner.run(model) end) |> IO.inspect()

--- a/lib/meow_nx.ex
+++ b/lib/meow_nx.ex
@@ -1,0 +1,20 @@
+defmodule MeowNx do
+  @moduledoc """
+  A set of tensor representations and evolutionary operations
+  to be used with the `Meow` core.
+
+  `MeowNx` focuses on numerical performance of the underlying
+  evolutionary operations. Built on top of the `Nx` library,
+  it can be accelerated by using any `Nx` compiler or backend
+  of choice. For instance, you can use the `EXLA` compiler to
+  produce highly optimised code for your CPU or even GPU.
+
+  `MeowNx` represents the whole population as a single tensor
+  and operations are then applied to such tensor. Thanks to
+  this "batched" approach (working on all individuals at once)
+  we can leverage efficient tensor operations.
+
+  `MeowNx` provides a number of numerical definitions,
+  as well as `Meow` operation definitions on top of that.
+  """
+end

--- a/lib/meow_nx/crossover.ex
+++ b/lib/meow_nx/crossover.ex
@@ -23,7 +23,7 @@ defmodule MeowNx.Crossover do
   # and the genomes tensor with swapped adjacent rows as y.
   # Consequently parent rows (a, b) in tensor x correspond
   # to rows (b, a) in tensor y, which means we perform all
-  # operaitons on every pair of parents twice.
+  # operations on every pair of parents twice.
 
   @doc """
   Performs uniform crossover.
@@ -102,10 +102,10 @@ defmodule MeowNx.Crossover do
 
     * `:alpha` - parameter controlling how far new genes
       may fall outside of the parent genes range.
-      Low values emphasise exploatation, while high values
+      Low values emphasise exploitation, while high values
       allow for exploration. Alpha of 0 is known as flat crossover,
       where new genes are drawn from the range `[x_i, y_i]`.
-      Alpha of 0.5 provides a balance between exploaration and exploatation.
+      Alpha of 0.5 provides a balance between exploration and exploitation.
       Defaults to `0.5`
 
   ## References

--- a/lib/meow_nx/crossover.ex
+++ b/lib/meow_nx/crossover.ex
@@ -1,0 +1,180 @@
+defmodule MeowNx.Crossover do
+  @moduledoc """
+  Numerical implementations of common crossover operations.
+
+  Crossover is a genetic operation that combines the genetic
+  information of parents to generate offspring.
+  It serves as a primary way of generating new solutions
+  in an evolutionary algorithm.
+
+  Most of the operations group parents into pairs and produce
+  a corresponding pair of offsprings.
+  """
+
+  import Nx.Defn
+
+  alias MeowNx.Utils
+
+  # Implementation note
+  #
+  # Since most operations produce two offsprings,
+  # we need to consider every pair of parents twice.
+  # Generally we designate the original genomes tensor as x
+  # and the genomes tensor with swapped adjacent rows as y.
+  # Consequently parent rows (a, b) in tensor x correspond
+  # to rows (b, a) in tensor y, which means we perform all
+  # operaitons on every pair of parents twice.
+
+  @doc """
+  Performs uniform crossover.
+
+  For parent genomes $x$ and $y$, this operation swaps genes
+  $x_i$ and $y_i$ according to the given probability.
+
+  ## Options
+
+    * `:probability` - the probability of corresponding parent
+      genes being swapped. Defaults to `0.5`
+
+  ## References
+
+    * [On the Virtues of Parameterized Uniform Crossover](http://www.mli.gmu.edu/papers/91-95/91-18.pdf)
+  """
+  defn uniform(parents, opts \\ []) do
+    opts = keyword!(opts, probability: 0.5)
+    probability = opts[:probability]
+
+    {n, length} = Nx.shape(parents)
+    half_n = transform(n, &div(&1, 2))
+
+    swapped_parents = Utils.swap_adjacent_rows(parents)
+
+    swap? =
+      Nx.random_uniform({half_n, length})
+      |> Nx.less_equal(probability)
+      |> Utils.duplicate_rows()
+
+    Nx.select(swap?, swapped_parents, parents)
+  end
+
+  @doc """
+  Performs single-point crossover.
+
+  For parent genomes $x$ and $y$, this operation chooses
+  a random split point and swaps all genes $x_i$, $y_i$
+  on one side of that split point.
+  """
+  defn single_point(parents) do
+    {n, length} = Nx.shape(parents)
+    half_n = transform(n, &div(&1, 2))
+
+    swapped_parents = Utils.swap_adjacent_rows(parents)
+
+    # Generate n / 2 split points (like [5, 2, 3]), and replicate
+    # them for adjacent parents (like [5, 5, 2, 2, 3, 3])
+    split_idx =
+      Nx.random_uniform({half_n, 1}, 1, n - 1)
+      |> Utils.duplicate_rows()
+
+    swap? = Nx.iota({1, length}) |> Nx.less_equal(split_idx)
+
+    Nx.select(swap?, swapped_parents, parents)
+  end
+
+  @doc """
+  Performs blend-alpha crossover, also referred to as BLX-alpha.
+
+  For parent genomes $x$ and $y$, a new offspring is produced
+  by uniformly drawing new genes $z_i$ from the range
+  $[x_i - \\alpha (y_i - x_i), y_i + \\alpha (y_i - x_i)]$, assuming $x_i < y_i$
+
+  In other words each of the new genes $z_i$ is either in
+  the range $[x_i, y_i]$ or slightly outside of that range,
+  depending on the parameter alpha.
+
+  Similarly to other crossover operations, this one also produces
+  two offsprings for every pair of parents.
+  Moreover, these offspring are symmetric, in the sense
+  that the mean value of their genomes (i.e. the mean genome)
+  is the same as the mean value of the parent ganomes.
+
+  ## Options
+
+    * `:alpha` - parameter controlling how far new genes
+      may fall outside of the parent genes range.
+      Low values emphasise exploatation, while high values
+      allow for exploration. Alpha of 0 is known as flat crossover,
+      where new genes are drawn from the range `[x_i, y_i]`.
+      Alpha of 0.5 provides a balance between exploaration and exploatation.
+      Defaults to `0.5`
+
+  ## References
+
+    * [Tackling Real-Coded Genetic Algorithms: Operators and Tools for Behavioural Analysis](https://sci2s.ugr.es/sites/default/files/files/ScientificImpact/AIRE12-1998.PDF), Section 4.3
+    * [Multiobjective Evolutionary Algorithms forElectric Power Dispatch Problem](https://www.researchgate.net/figure/Blend-crossover-operator-BLX_fig1_226044085), Fig. 1.
+  """
+  defn blend_alpha(parents, opts \\ []) do
+    opts = keyword!(opts, [:alpha])
+    alpha = opts[:alpha]
+
+    {n, length} = Nx.shape(parents)
+    half_n = transform(n, &div(&1, 2))
+
+    {x, y} = {parents, Utils.swap_adjacent_rows(parents)}
+
+    # This may look differently from the presented formula,
+    # but is in fact equivalent. Also the distance y - x
+    # may be negative (for y < x), but then we shift from x
+    # in the opposite direction, so it works as expected.
+
+    gamma = (1 + 2 * alpha) * Nx.random_uniform({half_n, length}) - alpha
+    gamma = Utils.duplicate_rows(gamma)
+
+    x + gamma * (y - x)
+  end
+
+  @doc """
+  Performs simulated binary crossover, also referred to as SBX.
+
+  This operation is a real representation counterpart of the single-point
+  crossover applied to binary representation (hence the name).
+  It was designed such that it provides the same characteristics,
+  see the referenced papers for more details.
+
+  ## Options
+
+    * `:eta` - parameter controlling how similar offsprings
+      are to the parents. Higher values imply closer resemblance,
+      lower values imply more significant difference. Required.
+
+  ## References
+
+    * [Self-Adaptive Genetic Algorithms with Simulated Binary Crossover](https://eldorado.tu-dortmund.de/bitstream/2003/5370/1/ci61.pdf)
+    * [Engineering Analysis and Design Using Genetic Algorithms / Lecture 4: Real-Coded Genetic Algorithms](https://engineering.purdue.edu/~sudhoff/ee630/Lecture04.pdf)
+  """
+  defn simulated_binary(parents, opts \\ []) do
+    opts = keyword!(opts, [:eta])
+    eta = opts[:eta]
+
+    {n, length} = Nx.shape(parents)
+    half_n = transform(n, &div(&1, 2))
+
+    {x, y} = {parents, Utils.swap_adjacent_rows(parents)}
+
+    beta_base =
+      Nx.random_uniform({half_n, length})
+      |> Nx.map(fn u ->
+        # TODO: does not work with BinaryBackend, see https://github.com/elixir-nx/nx/issues/395
+        if Nx.less(u, 0.5) do
+          2 * u
+        else
+          1 / (2 * (1 - u))
+        end
+      end)
+
+    beta = Nx.power(beta_base, 1 / (eta + 1))
+    beta = Utils.duplicate_rows(beta)
+
+    0.5 * ((1 + beta) * x + (1 - beta) * y)
+  end
+end

--- a/lib/meow_nx/mutation.ex
+++ b/lib/meow_nx/mutation.ex
@@ -1,0 +1,86 @@
+defmodule MeowNx.Mutation do
+  @moduledoc """
+  Numerical implementations of common mutation operations.
+
+  Mutation is a genetic operation that randomly alters genetic
+  information of some individuals within the population,
+  usually according to a fixed probability.
+  Mutation is used to maintain genetic diversity within the population
+  as it steps from one generation to another. It effectively introduces
+  a bit of additional randomness to the evolutionary algorithm, so that
+  more diversified solutions are explored. It may also helps to reduce
+  too rapid convergence of the algorithm to a local minimum.
+  """
+
+  import Nx.Defn
+
+  @doc """
+  Performs simple uniform replacement mutation.
+
+  Replaces every mutated gene with a random value drawn
+  uniformly from the given range.
+
+  Every gene has the same chance of mutation,
+  configured with `probability`.
+
+  ## Options
+
+    * `:probability` - the probability of each gene
+      getting mutated. Required.
+
+    * `:min` - the lower bound of the range to draw from.
+      Required.
+
+    * `:min` - the upper bound of the range to draw from.
+      Required.
+
+  """
+  defn replace_uniform(genomes, opts \\ []) do
+    opts = keyword!(opts, [:probability, :min, :max])
+    probability = opts[:probability]
+    min = opts[:min]
+    max = opts[:max]
+
+    shape = Nx.shape(genomes)
+
+    # Mutate each gene separately with the given probability
+    mutate? = Nx.random_uniform(shape) |> Nx.less(probability)
+    mutated = Nx.random_uniform(shape, min, max)
+    Nx.select(mutate?, mutated, genomes)
+  end
+
+  @doc """
+  Performs Gaussian shift mutation.
+
+  Adds a random value to every mutated gene.
+  The value is drawn from a normal distribution
+  with mean 0 and the specified standard deviation.
+
+  Every gene has the same chance of mutation,
+  configured with `probability`.
+
+  ## Options
+
+    * `:probability` - the probability of each gene
+      getting mutated. Required.
+
+    * `:sigma` - standard deviation of the normal
+      distribution used for mutation. Defaults to 1.
+
+  ## References
+
+    * [Adaptive Mutation Strategies for Evolutionary Algorithms](https://www.dynardo.de/fileadmin/Material_Dynardo/WOST/Paper/wost2.0/AdaptiveMutation.pdf), Section 3.1
+  """
+  defn shift_gaussian(genomes, opts \\ []) do
+    opts = keyword!(opts, [:probability, sigma: 1])
+    probability = opts[:probability]
+    sigma = opts[:sigma]
+
+    shape = Nx.shape(genomes)
+
+    # Mutate each gene separately with the given probability
+    mutate? = Nx.random_uniform(shape) |> Nx.less(probability)
+    mutated = genomes + Nx.random_normal(shape, 0.0, sigma)
+    Nx.select(mutate?, mutated, genomes)
+  end
+end

--- a/lib/meow_nx/mutation.ex
+++ b/lib/meow_nx/mutation.ex
@@ -8,7 +8,7 @@ defmodule MeowNx.Mutation do
   Mutation is used to maintain genetic diversity within the population
   as it steps from one generation to another. It effectively introduces
   a bit of additional randomness to the evolutionary algorithm, so that
-  more diversified solutions are explored. It may also helps to reduce
+  more diversified solutions are explored. It may also help to reduce
   too rapid convergence of the algorithm to a local minimum.
   """
 

--- a/lib/meow_nx/op/mutation.ex
+++ b/lib/meow_nx/op/mutation.ex
@@ -1,32 +1,34 @@
 defmodule MeowNx.Op.Mutation do
-  import Nx.Defn
   alias Meow.Op
+  alias MeowNx.Mutation
 
-  def replace_random_uniform(probability, min, max) do
+  def replace_uniform(probability, min, max) do
     opts = [probability: probability, min: min, max: max]
 
     %Op{
-      name: "[Nx] Mutation replace random uniform",
+      name: "[Nx] Mutation replace uniform",
       requires_fitness: false,
       invalidates_fitness: true,
       impl: fn population, _ctx ->
         Op.map_genomes(population, fn genomes ->
-          Nx.Defn.jit(&replace_random_uniform_impl(&1, opts), [genomes], compiler: EXLA)
+          Nx.Defn.jit(&Mutation.replace_uniform(&1, opts), [genomes], compiler: EXLA)
         end)
       end
     }
   end
 
-  defnp replace_random_uniform_impl(genomes, opts \\ []) do
-    probability = opts[:probability]
-    min = opts[:min]
-    max = opts[:max]
+  def shift_gaussian(probability, opts \\ []) do
+    opts = [probability: probability, sigma: opts[:sigma] || 1]
 
-    shape = Nx.shape(genomes)
-
-    # Mutate each gene separately with the given probability
-    sel = Nx.random_uniform(shape) |> Nx.less(probability)
-    new = Nx.random_uniform(shape, min, max)
-    Nx.select(sel, new, genomes)
+    %Op{
+      name: "[Nx] Mutation shift Gaussian",
+      requires_fitness: false,
+      invalidates_fitness: true,
+      impl: fn population, _ctx ->
+        Op.map_genomes(population, fn genomes ->
+          Nx.Defn.jit(&Mutation.shift_gaussian(&1, opts), [genomes], compiler: EXLA)
+        end)
+      end
+    }
   end
 end

--- a/lib/meow_nx/op/selection.ex
+++ b/lib/meow_nx/op/selection.ex
@@ -1,10 +1,8 @@
 defmodule MeowNx.Op.Selection do
-  import Nx.Defn
   alias Meow.Op
-  alias MeowNx.Utils
+  alias MeowNx.Selection
 
   def tournament(n) do
-    # TODO: support percentage, something like {:fraction, 0.2}
     opts = [n: n]
 
     %Op{
@@ -13,41 +11,13 @@ defmodule MeowNx.Op.Selection do
       invalidates_fitness: false,
       impl: fn population, _ctx ->
         Op.map_genomes_and_fitness(population, fn genomes, fitness ->
-          Nx.Defn.jit(&tournament_impl(&1, &2, opts), [genomes, fitness], compiler: EXLA)
+          Nx.Defn.jit(&Selection.tournament(&1, &2, opts), [genomes, fitness], compiler: EXLA)
         end)
       end
     }
   end
 
-  defnp tournament_impl(genomes, fitness, opts \\ []) do
-    final_n = opts[:n]
-
-    {n, length} = Nx.shape(genomes)
-
-    # Reshape fitness into 2D, so our `gather_rows` works fine
-    fitness = Nx.reshape(fitness, {n, 1})
-
-    idx1 = Nx.random_uniform({final_n}, 0, n, type: {:u, 32})
-    idx2 = Nx.random_uniform({final_n}, 0, n, type: {:u, 32})
-
-    parents1 = Utils.gather_rows(genomes, idx1)
-    fitness1 = Utils.gather_rows(fitness, idx1)
-
-    parents2 = Utils.gather_rows(genomes, idx2)
-    fitness2 = Utils.gather_rows(fitness, idx2)
-
-    best_fitness = Nx.greater(fitness1, fitness2)
-    best_genomes = Nx.broadcast(best_fitness, {final_n, length})
-
-    fitness = Nx.select(best_fitness, fitness1, fitness2) |> Nx.reshape({final_n})
-    genomes = Nx.select(best_genomes, parents1, parents2)
-
-    {genomes, fitness}
-  end
-
   def natural(n) do
-    # TODO: support percentage, something like {:fraction, 0.2}
-    # TODO: validate that n is not larget than population's
     opts = [n: n]
 
     %Op{
@@ -56,24 +26,9 @@ defmodule MeowNx.Op.Selection do
       invalidates_fitness: false,
       impl: fn population, _ctx ->
         Op.map_genomes_and_fitness(population, fn genomes, fitness ->
-          Nx.Defn.jit(&natural_impl(&1, &2, opts), [genomes, fitness], compiler: EXLA)
+          Nx.Defn.jit(&Selection.natural(&1, &2, opts), [genomes, fitness], compiler: EXLA)
         end)
       end
     }
-  end
-
-  defnp natural_impl(genomes, fitness, opts \\ []) do
-    final_n = opts[:n]
-    {n, _} = Nx.shape(genomes)
-
-    best_fitness_idx = Nx.argsort(fitness, comparator: :desc)[0..(final_n - 1)]
-
-    best_genomes = Utils.gather_rows(genomes, best_fitness_idx)
-
-    # Reshape fitness into 2D, so our `gather_rows` works fine
-    fitness = Nx.reshape(fitness, {n, 1})
-    best_fitness = Utils.gather_rows(fitness, best_fitness_idx) |> Nx.reshape({final_n})
-
-    {best_genomes, best_fitness}
   end
 end

--- a/lib/meow_nx/selection.ex
+++ b/lib/meow_nx/selection.ex
@@ -65,7 +65,7 @@ defmodule MeowNx.Selection do
   """
   defn natural(genomes, fitness, opts \\ []) do
     # TODO: support percentage, something like {:fraction, 0.2}
-    # TODO: validate that n is not larget than population size
+    # TODO: validate that n is not larger than population size
     result_n = opts[:n]
 
     sort_idx = Nx.argsort(fitness, comparator: :desc)

--- a/lib/meow_nx/selection.ex
+++ b/lib/meow_nx/selection.ex
@@ -1,0 +1,79 @@
+defmodule MeowNx.Selection do
+  @moduledoc """
+  Numerical implementations of common selection operations.
+
+  Selection is a genetic operation that picks a number
+  of individuals out of a population. Oftentimes those
+  individuals are then used for breeding (crossover).
+  """
+
+  import Nx.Defn
+
+  alias MeowNx.Utils
+
+  @doc """
+  Performs tournament selection with tournament size of 2.
+
+  Returns a `{genomes, fitness}` tuple with the selected individuals.
+
+  Randomly creates `n` groups of individuals (2 per group)
+  and picks the best individual from each group according to fitness.
+
+  ## Options
+
+    * `:n` - the number of individuals to select. Required.
+  """
+  defn tournament(genomes, fitness, opts \\ []) do
+    # TODO: support percentage, something like {:fraction, 0.2}
+    opts = keyword!(opts, [:n])
+    result_n = opts[:n]
+
+    {n, length} = Nx.shape(genomes)
+
+    idx1 = Nx.random_uniform({result_n}, 0, n, type: {:u, 32})
+    idx2 = Nx.random_uniform({result_n}, 0, n, type: {:u, 32})
+
+    parents1 = Utils.gather_rows(genomes, idx1)
+    fitness1 = Utils.gather_scalars(fitness, idx1)
+
+    parents2 = Utils.gather_rows(genomes, idx2)
+    fitness2 = Utils.gather_scalars(fitness, idx2)
+
+    wins? = Nx.greater(fitness1, fitness2)
+    winning_fitness = Nx.select(wins?, fitness1, fitness2)
+
+    winning_genomes =
+      wins?
+      |> Nx.reshape({result_n, 1})
+      |> Nx.broadcast({result_n, length})
+      |> Nx.select(parents1, parents2)
+
+    {winning_genomes, winning_fitness}
+  end
+
+  @doc """
+  Performs natural selection.
+
+  Returns a `{genomes, fitness}` tuple with the selected individuals.
+
+  Sorts individuals according to fitness and picks the `n` fittest.
+
+  ## Options
+
+    * `:n` - the number of individuals to select.
+      Must not exceed population size. Required.
+  """
+  defn natural(genomes, fitness, opts \\ []) do
+    # TODO: support percentage, something like {:fraction, 0.2}
+    # TODO: validate that n is not larget than population size
+    result_n = opts[:n]
+
+    sort_idx = Nx.argsort(fitness, comparator: :desc)
+    top_idx = sort_idx[0..(result_n - 1)]
+
+    best_genomes = Utils.gather_rows(genomes, top_idx)
+    best_fitness = Utils.gather_scalars(fitness, top_idx)
+
+    {best_genomes, best_fitness}
+  end
+end

--- a/lib/meow_nx/utils.ex
+++ b/lib/meow_nx/utils.ex
@@ -1,18 +1,69 @@
 defmodule MeowNx.Utils do
+  @moduledoc false
+
   import Nx.Defn
 
-  # This is a hack for doing gather on 2d tensor.
-  # Hopefully gather comes along: https://github.com/elixir-nx/nx/issues/223
-  #
-  # `t` is a 2d tensor and `idx` is a 1d tensor with indices of rows
-  # to select for the new 2d tensor.
-  defn gather_rows(t, idx) do
-    # n is the number of rows in the resulting 2d tensor
-    {n} = Nx.shape(idx)
-    {x, _y} = Nx.shape(t)
+  @doc """
+  Given a 2-dimensional tensor and a 1-dimensional tensor
+  of indices, builds a new 2-dimensional tensor by stacking
+  rows from the original tensor at the given indices.
 
-    # Each row is a one-hot encoding of which row from `t` to choose
-    selector = Nx.equal(Nx.reshape(idx, {n, 1}), Nx.iota({1, x}))
+  This operation is a specific case of a generic *gather* operation,
+  which is not yet implemented in `Nx`, but is on the roadmap.
+  See https://github.com/elixir-nx/nx/issues/223
+  """
+  # TODO: replace with `Nx.gather` once it's there
+  defn gather_rows(t, idx) do
+    {n, _} = Nx.shape(t)
+    {result_n} = Nx.shape(idx)
+
+    # Each selector row is a one-hot encoding of which row from `t` to choose
+    selector =
+      Nx.equal(
+        Nx.reshape(idx, {result_n, 1}),
+        Nx.iota({1, n})
+      )
+
     Nx.dot(selector, t)
+  end
+
+  @doc """
+  Same as `gather_rows/2` but for a 1-dimensional tensor.
+  """
+  defn gather_scalars(t, idx) do
+    {n} = Nx.shape(t)
+    {final_n} = Nx.shape(idx)
+
+    t
+    |> Nx.reshape({n, 1})
+    |> gather_rows(idx)
+    |> Nx.reshape({final_n})
+  end
+
+  @doc """
+  Given a 2-dimensional tensor swaps each consecutive
+  pair of rows.
+  """
+  defn swap_adjacent_rows(t) do
+    {n, m} = Nx.shape(t)
+    half_n = transform(n, &div(&1, 2))
+
+    t
+    |> Nx.reshape({half_n, 2, m})
+    |> Nx.reverse(axes: [1])
+    |> Nx.reshape({n, m})
+  end
+
+  @doc """
+  Given a 2-dimensional tensor replicates each row into
+  two adjacent rows.
+  """
+  defn duplicate_rows(t) do
+    {n, m} = Nx.shape(t)
+    twice_n = transform(n, &(&1 * 2))
+
+    t
+    |> Nx.tile([1, 2])
+    |> Nx.reshape({twice_n, m})
   end
 end


### PR DESCRIPTION
Adds new operations:

* BLX-alpha crossover
* SBX crossover
* Gaussian mutation

I also moved all numerical definitions to their own modules, so that they can be tested and used in separation. This way the `MeowNx.Op.*` modules simply build on top of that, without hiding the definitions underneath.