### PR TITLE
Support multiple populations and implement migration operators

### DIFF
--- a/lib/meow/model.ex
+++ b/lib/meow/model.ex
@@ -44,9 +44,16 @@ defmodule Meow.Model do
 
   Each pipeline defines how a single population evolves,
   so multiple pipelines imply multi-population model.
+
+  ## Options
+
+    * `:duplicate` - how many copies of the pipeline to add.
+      Multiple copies imply a multi-population algorithm. Defaults to 1.
   """
   @spec add_pipeline(t(), Pipeline.t()) :: t()
-  def add_pipeline(model, pipeline) do
-    %{model | pipelines: model.pipelines ++ [pipeline]}
+  def add_pipeline(model, pipeline, opts \\ []) do
+    copies = Keyword.get(opts, :duplicate, 1)
+    new_pipelines = List.duplicate(pipeline, copies)
+    %{model | pipelines: model.pipelines ++ new_pipelines}
   end
 end

--- a/lib/meow/op.ex
+++ b/lib/meow/op.ex
@@ -1,24 +1,34 @@
 defmodule Meow.Op do
+  @moduledoc """
+  A structure describing an evolutionary operation.
+
+  Operation is a single step in an evolutionary pipeline
+  and is responsible for transforming the population from
+  one state into another state.
+
+  The structure carries a number of operation information
+  relevant to the framework, as well as an actual implementation
+  of the operation.
+  """
+
   @enforce_keys [:name, :impl, :requires_fitness, :invalidates_fitness]
 
   defstruct [:name, :impl, :requires_fitness, :invalidates_fitness]
 
-  alias Meow.{Population, Model}
+  alias Meow.{Population, Op}
 
   @type t :: %__MODULE__{
           name: String.t(),
-          impl: (Population.t(), context() -> Population.t()),
+          impl: (Population.t(), Op.Context.t() -> Population.t()),
           requires_fitness: boolean(),
           invalidates_fitness: boolean()
         }
-
-  @type context :: %{evaluate: Model.evaluate()}
 
   @doc """
   Applies `operation` to `population` and returns
   a new transformed population.
   """
-  @spec apply(Population.t(), t(), context()) :: Population.t()
+  @spec apply(Population.t(), t(), Op.Context.t()) :: Population.t()
   def apply(population, operation, ctx)
 
   def apply(%{fitness: nil}, %{requires_fitness: true}, _ctx) do

--- a/lib/meow/op/context.ex
+++ b/lib/meow/op/context.ex
@@ -1,0 +1,16 @@
+defmodule Meow.Op.Context do
+  @moduledoc """
+  Additional information available to operations
+  that is not strictly related to the transformed
+  population.
+  """
+
+  defstruct [:evaluate, :population_pids]
+
+  alias Meow.Model
+
+  @type t :: %__MODULE__{
+          evaluate: Model.evaluate(),
+          population_pids: list(pid())
+        }
+end

--- a/lib/meow/op/flow.ex
+++ b/lib/meow/op/flow.ex
@@ -1,16 +1,16 @@
 defmodule Meow.Op.Flow do
   alias Meow.{Op, Pipeline}
 
-  def split_merge(split_fun, pipelines, merge_fun) do
+  def split_join(split_fun, pipelines, join_fun) do
     requires_fitness = Enum.any?(pipelines, fn %{ops: [op | _]} -> op.requires_fitness end)
 
     %Op{
-      name: "Flow: split merge",
+      name: "Flow: split join",
       # This operation itself doesn't require fitness,
       # but if any pipeline does, then we eagerly do so as well.
       requires_fitness: requires_fitness,
       # This operation itself doesn't invalidate fitness,
-      # it just merges results of the underlying pipelines.
+      # it just joins results of the underlying pipelines.
       invalidates_fitness: false,
       impl: fn population, ctx ->
         population
@@ -19,7 +19,7 @@ defmodule Meow.Op.Flow do
         |> Enum.map(fn {population, pipeline} ->
           Pipeline.apply(population, pipeline, ctx)
         end)
-        |> merge_fun.()
+        |> join_fun.()
       end
     }
   end

--- a/lib/meow/op/multi.ex
+++ b/lib/meow/op/multi.ex
@@ -1,0 +1,151 @@
+defmodule Meow.Op.Multi do
+  alias Meow.{Op, Pipeline, Population, Topology}
+
+  @doc """
+  Builds an emigration operation.
+
+  Emigration involves selecting a number of interesting
+  individuals and sending them to other populations.
+  The group of emigrants is determined by the given selection
+  operation and distributed according to the given topology.
+
+  ## Options
+
+    * `:interval` - the interval (number of generations)
+      determining how often emigration takes place. Defaults to 1.
+
+    * `:number_of_targets` - the number of neighbours to send
+      the selected individuals to. Must be either a number
+      or a range, in which case the number is randomly
+      drawn every time. Defaults to 1.
+  """
+  @spec emigrate(Op.t(), Topology.topology_fun(), keyword()) :: Op.t()
+  def emigrate(selection_op, topology_fun, opts \\ []) do
+    interval = Keyword.get(opts, :interval, 1)
+
+    targets_range =
+      case Keyword.get(opts, :number_of_targets, 1) do
+        n when is_integer(n) ->
+          n..n
+
+        min..max ->
+          min..max
+
+        other ->
+          raise ArgumentError,
+                "expected :number_of_targets to be either a number or a range, got: #{inspect(other)}"
+      end
+
+    %Op{
+      name: "Multi-population: emigration",
+      requires_fitness: false,
+      invalidates_fitness: false,
+      impl: fn population, ctx ->
+        if length(ctx.population_pids) > 1 and rem(population.generation, interval) == 0 do
+          neighbour_pids = find_neighbour_pids(ctx.population_pids, topology_fun)
+          number_of_targets = Enum.random(targets_range)
+
+          if number_of_targets > 0 and length(neighbour_pids) >= number_of_targets do
+            target_pids = Enum.take_random(neighbour_pids, number_of_targets)
+
+            %{genomes: emigrants} = pipe_through_operation(population, selection_op, ctx)
+
+            for target_pid <- target_pids do
+              send(target_pid, {:migrants, emigrants})
+            end
+          end
+        end
+
+        population
+      end
+    }
+  end
+
+  defp find_neighbour_pids(pids, topology_fun) do
+    self_idx = Enum.find_index(pids, &(&1 == self()))
+
+    pids
+    |> length()
+    |> topology_fun.(self_idx)
+    |> Enum.map(fn neighbour_idx -> Enum.at(pids, neighbour_idx) end)
+  end
+
+  defp pipe_through_operation(population, operation, ctx) do
+    pipeline = Pipeline.new([operation])
+    Pipeline.apply(population, pipeline, ctx)
+  end
+
+  @doc """
+  Builds an immigration operation.
+
+  Immigration involves receiving a number of migrated
+  individuals and incorporating them into the population.
+
+  `size_to_selection_op` must be a function that given
+  the shrunk population size returns a selection operation
+  for that size. This effectively allows to get rid
+  of some individuals and replace them with the immigrated ones.
+
+  ## Options
+
+    * `:interval` - the interval (number of generations)
+      determining how often immigration takes place. Defaults to 1.
+
+    * `:blocking` - whether to wait for immigration message
+      if not already in the process mailbox. Setting this
+      to `false` improves efficiency, but makes the algorithm
+      less deterministic. Defaults to `true`.
+
+    * `:timeout` - the number of milliseconds to await immigrants for.
+      Reaching the timeout results in `RuntimeError` as it most likely
+      indicates that the algorithm run into deadlock
+      (populations waiting for each other). Defaults to `20_000`.
+  """
+  @spec immigrate((non_neg_integer() -> Op.t()), keyword()) :: Op.t()
+  def immigrate(size_to_selection_op, opts \\ []) do
+    interval = Keyword.get(opts, :interval, 1)
+    blocking = Keyword.get(opts, :blocking, true)
+    timeout = Keyword.get(opts, :timeout, 20_000)
+
+    %Op{
+      name: "Multi-population: immigration",
+      requires_fitness: false,
+      invalidates_fitness: true,
+      impl: fn population, ctx ->
+        with true <-
+               length(ctx.population_pids) > 1 and rem(population.generation, interval) == 0,
+             {:ok, immigrants} <- await_migrants(blocking, timeout) do
+          immigrants_population = Population.new(immigrants, population.representation_spec)
+
+          selection_size =
+            (Population.size(population) - Population.size(immigrants_population)) |> max(0)
+
+          selection_op = size_to_selection_op.(selection_size)
+
+          # Shrink the population to make space for immigrants
+          shrunk_population = pipe_through_operation(population, selection_op, ctx)
+
+          Population.concatenate([shrunk_population, immigrants_population])
+        else
+          _ -> population
+        end
+      end
+    }
+  end
+
+  defp await_migrants(true = _blocking, timeout) do
+    receive do
+      {:migrants, genomes} -> {:ok, genomes}
+    after
+      timeout -> raise RuntimeError, "immigration timed out after #{timeout}ms"
+    end
+  end
+
+  defp await_migrants(false = _blocking, _timeout) do
+    receive do
+      {:migrants, genomes} -> {:ok, genomes}
+    after
+      0 -> :error
+    end
+  end
+end

--- a/lib/meow/population.ex
+++ b/lib/meow/population.ex
@@ -7,11 +7,12 @@ defmodule Meow.Population do
   as well as information about the evolution progress.
   """
 
-  defstruct [:genomes, :fitness, generation: 0, terminated: false]
+  defstruct [:genomes, :fitness, :representation_spec, generation: 1, terminated: false]
 
   @type t :: %__MODULE__{
           genomes: genomes(),
           fitness: fitness(),
+          representation_spec: module(),
           generation: non_neg_integer(),
           terminated: boolean()
         }
@@ -41,6 +42,26 @@ defmodule Meow.Population do
   @type fitness :: any()
 
   @doc """
+  Initializes a population from genomes representation.
+  """
+  @spec new(genomes(), module()) :: t()
+  def new(genomes, representation_spec) do
+    %__MODULE__{
+      genomes: genomes,
+      generation: 1,
+      representation_spec: representation_spec
+    }
+  end
+
+  @doc """
+  Calculates population size based on the underlying representation.
+  """
+  @spec size(t()) :: non_neg_integer()
+  def size(population) do
+    population.representation_spec.population_size(population.genomes)
+  end
+
+  @doc """
   Returns a list of size `times` where every item is `population`.
   """
   @spec duplicate(t(), pos_integer()) :: list(t())
@@ -49,35 +70,67 @@ defmodule Meow.Population do
   end
 
   @doc """
-  Shortcut for `merge_with/3` when the same merge function
-  applies for both genomes and fitness.
+  Concatenats the given populations into a single population.
+
+  The resulting population includes genomes from all the populations
+  and is composed using `representation_spec` of the first population.
   """
-  @spec merge_with(list(t()), (genomes() | fitness() -> t())) :: t()
-  def merge_with(populations, merge_fun) do
-    merge_with(populations, merge_fun, merge_fun)
+  @spec concatenate(list(t())) :: t()
+  def concatenate(populations) do
+    representation_spec = same_representation_spec!(populations)
+
+    join_with(
+      populations,
+      &representation_spec.concatenate_genomes/1,
+      &representation_spec.concatenate_fitness/1
+    )
   end
 
   @doc """
-  Merges the given populations into a single population.
+  Shortcut for `join_with/3` when the same join function
+  applies for both genomes and fitness.
+  """
+  @spec join_with(list(t()), (genomes() | fitness() -> t())) :: t()
+  def join_with(populations, join_fun) do
+    join_with(populations, join_fun, join_fun)
+  end
 
-  Uses `genomes_merge_fun` and `fitness_merge_fun` to merge
+  @doc """
+  Joins the given populations into a single population.
+
+  Uses `genomes_join_fun` and `fitness_join_fun` to join
   genomes and fitness representations respectively.
   """
-  @spec merge_with(list(t()), (genomes() -> t()), (fitness() -> t())) :: t()
-  def merge_with(populations, genomes_merge_fun, fitness_merge_fun) do
+  @spec join_with(list(t()), (genomes() -> t()), (fitness() -> t())) :: t()
+  def join_with(populations, genomes_join_fun, fitness_join_fun) do
     %__MODULE__{
-      genomes: populations |> Enum.map(& &1.genomes) |> genomes_merge_fun.(),
-      fitness: populations |> Enum.map(& &1.fitness) |> merge_fitness(fitness_merge_fun),
+      genomes: populations |> Enum.map(& &1.genomes) |> genomes_join_fun.(),
+      fitness: populations |> Enum.map(& &1.fitness) |> join_fitness(fitness_join_fun),
       terminated: populations |> Enum.any?(& &1.terminated),
-      generation: populations |> Enum.map(& &1.generation) |> Enum.max()
+      generation: populations |> Enum.map(& &1.generation) |> Enum.max(),
+      representation_spec: same_representation_spec!(populations)
     }
   end
 
-  defp merge_fitness(fitness_list, merge_fun) do
+  defp join_fitness(fitness_list, join_fun) do
     if Enum.any?(fitness_list, &is_nil/1) do
       nil
     else
-      merge_fun.(fitness_list)
+      join_fun.(fitness_list)
+    end
+  end
+
+  defp same_representation_spec!(populations) do
+    populations
+    |> Enum.map(& &1.representation_spec)
+    |> Enum.uniq()
+    |> case do
+      [representation_spec] ->
+        representation_spec
+
+      _ ->
+        raise ArgumentError,
+              "the given populations have different representation spec, so they are not of compatible type"
     end
   end
 end

--- a/lib/meow/population.ex
+++ b/lib/meow/population.ex
@@ -70,7 +70,7 @@ defmodule Meow.Population do
   end
 
   @doc """
-  Concatenats the given populations into a single population.
+  Concatenates the given populations into a single population.
 
   The resulting population includes genomes from all the populations
   and is composed using `representation_spec` of the first population.

--- a/lib/meow/representation_spec.ex
+++ b/lib/meow/representation_spec.ex
@@ -1,0 +1,28 @@
+defmodule Meow.RepresentationSpec do
+  @moduledoc """
+  Defines a few basic operations for on a population representation.
+
+  Some core modules need to know how to perform certain
+  operations on genomes and those operations are representation
+  dependent, hence such specification needs to be provided.
+  """
+
+  alias Meow.Population
+
+  @doc """
+  Extracts population size from the given genomes representation.
+  """
+  @callback population_size(Population.genomes()) :: non_neg_integer()
+
+  @doc """
+  Concatenates genomes of multiple groups of individuals.
+  """
+  @callback concatenate_genomes(list(Population.genomes())) :: Population.genomes()
+
+  @doc """
+  Concatenates fitnesses of multiple groups of individuals.
+
+  The order of individuals should match the one from `concatenate_genomes/1`.
+  """
+  @callback concatenate_fitness(list(Population.fitness())) :: Population.fitness()
+end

--- a/lib/meow/runner.ex
+++ b/lib/meow/runner.ex
@@ -7,19 +7,35 @@ defmodule Meow.Runner do
   alias Meow.{Population, Pipeline, Model}
 
   @doc """
-  Iteratively transforms the population according to
-  the given model until the population is terminated.
+  Iteratively transforms populations according to
+  the given model until the populations are terminated.
   """
-  @spec run(Model.t()) :: Population.t()
+  @spec run(Model.t()) :: list(Population.t())
   def run(model) do
-    genomes = model.initializer.()
-    population = %Population{genomes: genomes, fitness: nil, generation: 1}
-    ctx = %{evaluate: model.evaluate}
+    runner_pid = self()
 
-    # TODO: support multiple pipelines (populations)
-    [pipeline] = model.pipelines
+    pids =
+      Enum.map(model.pipelines, fn pipeline ->
+        spawn_link(fn ->
+          {genomes, representation_spec} = model.initializer.()
+          population = Population.new(genomes, representation_spec)
 
-    run_population(population, pipeline, ctx)
+          receive do
+            {:initialize, pids} ->
+              ctx = %{evaluate: model.evaluate, population_pids: pids}
+              final_population = run_population(population, pipeline, ctx)
+              send(runner_pid, {:finished, final_population})
+          end
+        end)
+      end)
+
+    for pid <- pids, do: send(pid, {:initialize, pids})
+
+    Enum.map(pids, fn _ ->
+      receive do
+        {:finished, population} -> population
+      end
+    end)
   end
 
   defp run_population(population, pipeline, ctx) do

--- a/lib/meow/topology.ex
+++ b/lib/meow/topology.ex
@@ -1,0 +1,35 @@
+defmodule Meow.Topology do
+  @moduledoc """
+  A number of topology functions used in multi-population algorithms.
+
+  Topology defines communication scheme for multiple populations
+  and is essentially a directed graph, where every population
+  points to its direct neighbours.
+  """
+
+  @typedoc """
+  A topology function encodes a topology graph.
+
+  Given the number of populations and the index of a specific
+  population, topology function returns the list of neighbours
+  for this population.
+
+  Representing the topology via function has the benefit of being
+  population size agnostic.
+  """
+  @type topology_fun ::
+          (number_of_populations(), population_index() -> neighbour_population_indices())
+
+  @type number_of_populations :: pos_integer()
+  @type population_index :: non_neg_integer()
+  @type neighbour_population_indices :: list(population_index())
+
+  @doc """
+  Represents unidirectional ring topology.
+  """
+  @spec ring(number_of_populations(), population_index()) :: neighbour_population_indices()
+  def ring(n, idx) do
+    next_idx = (idx + 1) |> rem(n)
+    [next_idx]
+  end
+end

--- a/lib/meow_nx/crossover.ex
+++ b/lib/meow_nx/crossover.ex
@@ -106,7 +106,7 @@ defmodule MeowNx.Crossover do
       allow for exploration. Alpha of 0 is known as flat crossover,
       where new genes are drawn from the range `[x_i, y_i]`.
       Alpha of 0.5 provides a balance between exploration and exploitation.
-      Defaults to `0.5`
+      Defaults to `0.5`.
 
   ## References
 

--- a/lib/meow_nx/init.ex
+++ b/lib/meow_nx/init.ex
@@ -3,7 +3,8 @@ defmodule MeowNx.Init do
 
   def real_random_uniform(n, length, min, max) do
     fn ->
-      real_random_uniform_impl(n: n, length: length, min: min, max: max)
+      genomes = real_random_uniform_impl(n: n, length: length, min: min, max: max)
+      {genomes, MeowNx.RepresentationSpec}
     end
   end
 

--- a/lib/meow_nx/representation_spec.ex
+++ b/lib/meow_nx/representation_spec.ex
@@ -1,0 +1,22 @@
+defmodule MeowNx.RepresentationSpec do
+  @moduledoc """
+  Specification of population tensor representation.
+  """
+
+  @behaviour Meow.RepresentationSpec
+
+  @impl true
+  def population_size(genomes) do
+    genomes |> Nx.shape() |> elem(0)
+  end
+
+  @impl true
+  def concatenate_genomes(genomes_list) do
+    Nx.concatenate(genomes_list)
+  end
+
+  @impl true
+  def concatenate_fitness(fitness_list) do
+    Nx.concatenate(fitness_list)
+  end
+end

--- a/lib/meow_nx/selection.ex
+++ b/lib/meow_nx/selection.ex
@@ -68,7 +68,7 @@ defmodule MeowNx.Selection do
     # TODO: validate that n is not larger than population size
     result_n = opts[:n]
 
-    sort_idx = Nx.argsort(fitness, comparator: :desc)
+    sort_idx = Nx.argsort(fitness, direction: :desc)
     top_idx = sort_idx[0..(result_n - 1)]
 
     best_genomes = Utils.gather_rows(genomes, top_idx)


### PR DESCRIPTION
Extends the runner to start every pipeline in its own process and wait until all populations terminate. Lays the foundation for multi-population algorithms by introducing migration operation, split up into `emigrate` and `immigrate` for more control. The operations allow for configuring individual selection and migration topology.

A basic migration can be added to pipeline like so:

```elixir
# ...
Multi.emigrate(Selection.tournament(2), &Topology.ring/2, interval: 10),
Multi.immigrate(&Selection.natural(&1), interval: 10),
# ...
````

A couple relevant design details:

* for selecting emigrants we use an operation rather than an arbitrary function, as its easier to reuse operations and we get the benefits like fitness being handled automatically and possibility to compile with EXLA underneath
* during immigration we need to select which individuals are replaced, but this is effectively the same as selecting a subset of the population and then adding immigrants to the population. This way is much better than some kind of replacement function, for the same reasons as in the point above, and also replacement would generally require picking the worst individuals, so we couldn't reuse existing selection methods. Also note that instead of an operation we actually pass a function like `fn shrunk_size -> Selection.natural(shrunk_size) end`, as the selection size depends on the number of immigrants
* topology is defined as a function rather than a data structure, which makes it size agnostic, and is just more flexible