### PR TITLE
Measure evaluation time and keep track of best individual

### DIFF
--- a/examples/rastrigin.ex
+++ b/examples/rastrigin.ex
@@ -10,36 +10,38 @@ defmodule Rastrigin do
   alias Meow.{Model, Pipeline, Population, Topology}
   alias Meow.Op.{Termination, Flow, Multi}
   alias MeowNx.Init
-  alias MeowNx.Op.{Selection, Crossover, Mutation}
+  alias MeowNx.Op.{Selection, Crossover, Mutation, Metric}
 
   def model_simple() do
     Model.new(
-      Init.real_random_uniform(20, 100, -5.12, 5.12),
+      Init.real_random_uniform(100, 100, -5.12, 5.12),
       &evaluate/1
     )
     |> Model.add_pipeline(
       Pipeline.new([
-        Selection.tournament(20),
+        Selection.tournament(100),
         Crossover.uniform(0.5),
         Mutation.replace_uniform(0.001, -5.12, 5.12),
-        Termination.max_generations(50_000)
+        Metric.best_individual(),
+        Termination.max_generations(5_000)
       ])
     )
   end
 
   def model_simple_multi() do
     Model.new(
-      Init.real_random_uniform(20, 100, -5.12, 5.12),
+      Init.real_random_uniform(100, 100, -5.12, 5.12),
       &evaluate/1
     )
     |> Model.add_pipeline(
       Pipeline.new([
-        Selection.tournament(20),
+        Selection.tournament(100),
         Crossover.uniform(0.5),
-        Mutation.replace_uniform(0.001, -5.12, 5.12),
-        Multi.emigrate(Selection.tournament(2), &Topology.ring/2, interval: 10),
+        Mutation.shift_gaussian(0.001),
+        Multi.emigrate(Selection.tournament(5), &Topology.ring/2, interval: 10),
         Multi.immigrate(&Selection.natural(&1), interval: 10),
-        Termination.max_generations(50)
+        Metric.best_individual(),
+        Termination.max_generations(5_000)
       ]),
       duplicate: 3
     )
@@ -47,7 +49,7 @@ defmodule Rastrigin do
 
   def model_branching() do
     Model.new(
-      Init.real_random_uniform(20, 100, -5.12, 5.12),
+      Init.real_random_uniform(100, 100, -5.12, 5.12),
       &evaluate/1
     )
     |> Model.add_pipeline(
@@ -58,40 +60,18 @@ defmodule Rastrigin do
           &Population.duplicate(&1, 2),
           [
             Pipeline.new([
-              Selection.tournament(4)
+              Selection.natural(20)
             ]),
             Pipeline.new([
-              Selection.tournament(16),
-              Crossover.uniform(0.5),
-              Mutation.replace_uniform(0.001, -5.12, 5.12)
+              Selection.tournament(80),
+              Crossover.blend_alpha(0.5),
+              Mutation.shift_gaussian(0.001)
             ])
           ],
           &Population.concatenate/1
         ),
-        Termination.max_generations(50_000)
-      ])
-    )
-  end
-
-  def model_if() do
-    Model.new(
-      Init.real_random_uniform(20, 100, -5.12, 5.12),
-      &evaluate/1
-    )
-    |> Model.add_pipeline(
-      Pipeline.new([
-        Selection.tournament(20),
-        Flow.if(
-          fn population -> rem(population.generation, 2) == 0 end,
-          Pipeline.new([
-            Crossover.uniform(0.7)
-          ]),
-          Pipeline.new([
-            Crossover.uniform(0.3)
-          ])
-        ),
-        Mutation.replace_uniform(0.001, -5.12, 5.12),
-        Termination.max_generations(50_000)
+        Metric.best_individual(),
+        Termination.max_generations(5_000)
       ])
     )
   end
@@ -108,6 +88,6 @@ defmodule Rastrigin do
   end
 end
 
-model = Rastrigin.model_simple_multi()
+model = Rastrigin.model_branching()
 
-Meow.Runner.run(model) |> IO.inspect()
+Meow.Runner.run(model)

--- a/examples/rastrigin.ex
+++ b/examples/rastrigin.ex
@@ -109,4 +109,5 @@ defmodule Rastrigin do
 end
 
 model = Rastrigin.model_simple_multi()
-:timer.tc(fn -> Meow.Runner.run(model) end) |> IO.inspect()
+
+Meow.Runner.run(model) |> IO.inspect()

--- a/lib/meow/population.ex
+++ b/lib/meow/population.ex
@@ -7,14 +7,22 @@ defmodule Meow.Population do
   as well as information about the evolution progress.
   """
 
-  defstruct [:genomes, :fitness, :representation_spec, generation: 1, terminated: false]
+  defstruct [
+    :genomes,
+    :fitness,
+    :representation_spec,
+    generation: 1,
+    terminated: false,
+    metrics: %{}
+  ]
 
   @type t :: %__MODULE__{
           genomes: genomes(),
           fitness: fitness(),
           representation_spec: module(),
           generation: non_neg_integer(),
-          terminated: boolean()
+          terminated: boolean(),
+          metrics: %{}
         }
 
   @typedoc """
@@ -108,7 +116,10 @@ defmodule Meow.Population do
       fitness: populations |> Enum.map(& &1.fitness) |> join_fitness(fitness_join_fun),
       terminated: populations |> Enum.any?(& &1.terminated),
       generation: populations |> Enum.map(& &1.generation) |> Enum.max(),
-      representation_spec: same_representation_spec!(populations)
+      representation_spec: same_representation_spec!(populations),
+      # This is somehow arbitrary, but we cannot reasonably merge statistics
+      # and this approach should generally work as expected
+      metrics: Enum.max_by(populations, & &1.generation).metrics
     }
   end
 

--- a/lib/meow_nx/metric.ex
+++ b/lib/meow_nx/metric.ex
@@ -1,0 +1,15 @@
+defmodule MeowNx.Metric do
+  @moduledoc """
+  Numerical implementations of basic metrics.
+  """
+
+  import Nx.Defn
+
+  @doc """
+  Finds the best individual and their fitness.
+  """
+  defn best_individual(genomes, fitness) do
+    best_idx = Nx.argmax(fitness)
+    {genomes[best_idx], fitness[best_idx]}
+  end
+end

--- a/lib/meow_nx/mutation.ex
+++ b/lib/meow_nx/mutation.ex
@@ -72,7 +72,7 @@ defmodule MeowNx.Mutation do
     * [Adaptive Mutation Strategies for Evolutionary Algorithms](https://www.dynardo.de/fileadmin/Material_Dynardo/WOST/Paper/wost2.0/AdaptiveMutation.pdf), Section 3.1
   """
   defn shift_gaussian(genomes, opts \\ []) do
-    opts = keyword!(opts, [:probability, sigma: 1])
+    opts = keyword!(opts, [:probability, sigma: 1.0])
     probability = opts[:probability]
     sigma = opts[:sigma]
 

--- a/lib/meow_nx/op/metric.ex
+++ b/lib/meow_nx/op/metric.ex
@@ -1,0 +1,46 @@
+defmodule MeowNx.Op.Metric do
+  @moduledoc """
+  Metric operations backed by numerical definitions.
+
+  This module provides a compatibility layer for `Meow`,
+  while individual numerical definitions can be found
+  in `MeowNx.Metric`.
+  """
+
+  alias Meow.Op
+  alias MeowNx.Metric
+
+  @doc """
+  Builds a metric operation loging the best individual.
+
+  See `MeowNx.Metric.best_individual/2` for more details.
+  """
+  @spec best_individual() :: Op.t()
+  def best_individual() do
+    %Op{
+      name: "Metric: best individual",
+      requires_fitness: true,
+      invalidates_fitness: false,
+      impl: fn population, _ctx ->
+        # TODO: make compiler (and generally other options)
+        # configurable globally for the model
+        {best_genome, best_fitness} =
+          Nx.Defn.jit(&Metric.best_individual/2, [population.genomes, population.fitness],
+            compiler: EXLA
+          )
+
+        best_individual = %{
+          genome: best_genome,
+          fitness: Nx.to_scalar(best_fitness),
+          generation: population.generation
+        }
+
+        update_in(population.metrics, fn metrics ->
+          Map.update(metrics, :best_individual, best_individual, fn individual ->
+            Enum.max_by([individual, best_individual], & &1.fitness)
+          end)
+        end)
+      end
+    }
+  end
+end


### PR DESCRIPTION
This adds some useful output to `Meow.Runner.run/1`, currently including time stats and best individual if available. As for the metric operation we should revisit once we actually focus on metrics and logging, but good to have something in place already.

```
➜  meow git:(jk-measurement) elixir examples/rastrigin.ex 

====== Summary ======

Total time: 12.794586s
Population time (average): 12.731998s

====== Best individual ======

Fitness: -0.0
Generation: 3476
Genome: #Nx.Tensor<
  f32[100]
  [4.321498181525385e-6, 1.5882655134191737e-5, 1.1626498235273175e-5, 1.3183705050323624e-5, -2.3770155166857876e-5, 3.140622720820829e-5, -1.2996893929084763e-5, 3.6269020711188205e-6, -2.278404053868144e-6, -2.69220308837248e-5, 1.2596763554029167e-5, -2.412559842923656e-5, 3.026294962182874e-6, 9.230865543941036e-6, -1.4436975561693544e-6, -4.146858827880351e-6, -2.3031321688904427e-5, 8.853805411490612e-6, -3.099708919762634e-5, 2.2052867279853672e-5, 3.371473212609999e-5, -3.243360697524622e-5, -1.0103933163918555e-5, 9.81506582320435e-6, -3.3200335565197747e-6, -2.6765826532937353e-6, 2.6552401322987862e-5, -3.0929717468097806e-5, 2.1975483832648024e-5, 1.2003168876617565e-6, -7.437216027028626e-6, 1.2572376363095827e-5, -1.3274812772579025e-5, -7.228168669826118e-6, 7.946491678012535e-6, -4.6127747737045866e-6, -7.500610536226304e-6, -2.0641351511585526e-5, 5.562767910305411e-6, 3.171519347233698e-5, 1.3505615470421617e-6, -1.0860492693609558e-5, -2.457543450873345e-5, -7.747344170638826e-6, -1.8785679003485711e-6, 3.865660255542025e-5, -2.1675297830370255e-5, 3.0152552426443435e-5, -3.968531018472277e-6, 6.898751507833367e-6, ...]
>
```