### PR TITLE
Use Nx.take/3 and precompiled EXLA binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Docs](https://img.shields.io/badge/docs-gray.svg)](https://static.jonatanklosko.com/docs/meow)
 
-Multipopulation evolutionary optimisation workbench
+> **Disclaimer:** this is currently a work in progress.
 
-**Note: This is currently a work in progress**
+Multipopulation evolutionary optimisation workbench
 
 ## Usage
 
@@ -16,11 +16,8 @@ You can define the algorithm in a single Elixir script file like this:
 Mix.install([
   {:meow, "~> 0.1.0-dev", github: "jonatanklosko/meow"},
   {:nx, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "nx", override: true},
-  # To install EXLA you need a couple prerequisites (https://github.com/elixir-nx/nx/tree/main/exla#installation).
-  # Also note that the first installation takes a long time, because it involves
-  # compiling XLA from source. This will however be streamlined in the future,
-  # once pre-compiled binaries are available as part of EXLA.
   {:exla, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "exla"},
+  {:exla_precompiled, "~> 0.1.0-dev", github: "jonatanklosko/exla_precompiled"}
 ])
 
 # Define the evaluation function, in this case using Nx to work with MeowNx

--- a/examples/intro.exs
+++ b/examples/intro.exs
@@ -3,11 +3,8 @@
 Mix.install([
   {:meow, "~> 0.1.0-dev", github: "jonatanklosko/meow"},
   {:nx, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "nx", override: true},
-  # To install EXLA you need a couple prerequisites (https://github.com/elixir-nx/nx/tree/main/exla#installation).
-  # Also note that the first installation takes a long time, because it involves
-  # compiling XLA from source. This will however be streamlined in the future,
-  # once pre-compiled binaries are available as part of EXLA.
-  {:exla, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "exla"}
+  {:exla, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "exla"},
+  {:exla_precompiled, "~> 0.1.0-dev", github: "jonatanklosko/exla_precompiled"}
 ])
 
 # Define the evaluation function, in this case using Nx to work with MeowNx

--- a/examples/rastrigin.exs
+++ b/examples/rastrigin.exs
@@ -1,7 +1,6 @@
 Mix.install([
   {:exla, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "exla"},
   {:nx, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "nx", override: true},
-  {:benchee, "~> 1.0"},
   {:meow, path: __DIR__ |> Path.join("..") |> Path.expand()}
 ])
 

--- a/examples/rastrigin.exs
+++ b/examples/rastrigin.exs
@@ -1,7 +1,8 @@
 Mix.install([
-  {:exla, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "exla"},
+  {:meow, path: __DIR__ |> Path.join("..") |> Path.expand()},
   {:nx, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "nx", override: true},
-  {:meow, path: __DIR__ |> Path.join("..") |> Path.expand()}
+  {:exla, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "exla"},
+  {:exla_precompiled, "~> 0.1.0-dev", github: "jonatanklosko/exla_precompiled"}
 ])
 
 defmodule Rastrigin do

--- a/lib/meow_nx/selection.ex
+++ b/lib/meow_nx/selection.ex
@@ -9,8 +9,6 @@ defmodule MeowNx.Selection do
 
   import Nx.Defn
 
-  alias MeowNx.Utils
-
   @doc """
   Performs tournament selection with tournament size of 2.
 
@@ -33,11 +31,11 @@ defmodule MeowNx.Selection do
     idx1 = Nx.random_uniform({result_n}, 0, n, type: {:u, 32})
     idx2 = Nx.random_uniform({result_n}, 0, n, type: {:u, 32})
 
-    parents1 = Utils.gather_rows(genomes, idx1)
-    fitness1 = Utils.gather_scalars(fitness, idx1)
+    parents1 = Nx.take(genomes, idx1)
+    fitness1 = Nx.take(fitness, idx1)
 
-    parents2 = Utils.gather_rows(genomes, idx2)
-    fitness2 = Utils.gather_scalars(fitness, idx2)
+    parents2 = Nx.take(genomes, idx2)
+    fitness2 = Nx.take(fitness, idx2)
 
     wins? = Nx.greater(fitness1, fitness2)
     winning_fitness = Nx.select(wins?, fitness1, fitness2)
@@ -71,8 +69,8 @@ defmodule MeowNx.Selection do
     sort_idx = Nx.argsort(fitness, direction: :desc)
     top_idx = sort_idx[0..(result_n - 1)]
 
-    best_genomes = Utils.gather_rows(genomes, top_idx)
-    best_fitness = Utils.gather_scalars(fitness, top_idx)
+    best_genomes = Nx.take(genomes, top_idx)
+    best_fitness = Nx.take(fitness, top_idx)
 
     {best_genomes, best_fitness}
   end

--- a/lib/meow_nx/utils.ex
+++ b/lib/meow_nx/utils.ex
@@ -4,43 +4,6 @@ defmodule MeowNx.Utils do
   import Nx.Defn
 
   @doc """
-  Given a 2-dimensional tensor and a 1-dimensional tensor
-  of indices, builds a new 2-dimensional tensor by stacking
-  rows from the original tensor at the given indices.
-
-  This operation is a specific case of a generic *gather* operation,
-  which is not yet implemented in `Nx`, but is on the roadmap.
-  See https://github.com/elixir-nx/nx/issues/223
-  """
-  # TODO: replace with `Nx.gather` once it's there
-  defn gather_rows(t, idx) do
-    {n, _} = Nx.shape(t)
-    {result_n} = Nx.shape(idx)
-
-    # Each selector row is a one-hot encoding of which row from `t` to choose
-    selector =
-      Nx.equal(
-        Nx.reshape(idx, {result_n, 1}),
-        Nx.iota({1, n})
-      )
-
-    Nx.dot(selector, t)
-  end
-
-  @doc """
-  Same as `gather_rows/2` but for a 1-dimensional tensor.
-  """
-  defn gather_scalars(t, idx) do
-    {n} = Nx.shape(t)
-    {final_n} = Nx.shape(idx)
-
-    t
-    |> Nx.reshape({n, 1})
-    |> gather_rows(idx)
-    |> Nx.reshape({final_n})
-  end
-
-  @doc """
   Given a 2-dimensional tensor swaps each consecutive
   pair of rows.
   """

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Meow.MixProject do
   use Mix.Project
 
   @version "0.1.0-dev"
-  @description "Elixir bindings to Vega-Lite"
+  @description "Multipopulation evolutionary algorithms in Elixir"
 
   def project do
     [

--- a/mix.lock
+++ b/mix.lock
@@ -5,5 +5,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.15.1", "b5888c880d17d1cc3e598f05cdb5b5a91b7b17ac4eaf5f297cb697663a1094dd", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "db68c173234b07ab2a07f645a5acdc117b9f99d69ebf521821d89690ae6c6ec8"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
-  "nx": {:git, "https://github.com/elixir-nx/nx.git", "4d3de03e71f091c34f6e1482fa528efbc6d2d9af", [branch: "main", sparse: "nx"]},
+  "nx": {:git, "https://github.com/elixir-nx/nx.git", "65c05bd2cef5317316348f200e3dfa5f7a18d56b", [branch: "main", sparse: "nx"]},
 }

--- a/notebooks/rastrigin_intro.livemd
+++ b/notebooks/rastrigin_intro.livemd
@@ -11,7 +11,8 @@ and [EXLA](https://github.com/elixir-nx/nx/tree/main/exla) to compile them effec
 Mix.install([
   {:meow, "~> 0.1.0-dev", github: "jonatanklosko/meow"},
   {:nx, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "nx", override: true},
-  {:exla, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "exla"}
+  {:exla, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "exla"},
+  {:exla_precompiled, "~> 0.1.0-dev", github: "jonatanklosko/exla_precompiled"}
 ])
 ```
 


### PR DESCRIPTION
This integrates some upstream work I did, specifically:

* replaces the hacky `gather_rows`/`gather_scalars` with the new `Nx.take/3` function (https://github.com/elixir-nx/nx/pull/433)
* updates examples/scripts to install [`jonatanklosko/exla_precopmiled`](https://github.com/jonatanklosko/exla_precompiled), which downloads prebuilt EXLA binary if available and consequently saves hours of local compilation time