### PR TITLE
Add roulette and SUS selections

### DIFF
--- a/lib/meow_nx/utils.ex
+++ b/lib/meow_nx/utils.ex
@@ -5,7 +5,21 @@ defmodule MeowNx.Utils do
 
   @doc """
   Given a 2-dimensional tensor swaps each consecutive
-  pair of rows.
+  pairs of rows.
+
+  ## Examples
+
+      iex> t = Nx.iota({4, 2}, axis: 0)
+      iex> MeowNx.Utils.swap_adjacent_rows(t)
+      #Nx.Tensor<
+        s64[4][2]
+        [
+          [1, 1],
+          [0, 0],
+          [3, 3],
+          [2, 2]
+        ]
+      >
   """
   defn swap_adjacent_rows(t) do
     {n, m} = Nx.shape(t)
@@ -20,6 +34,20 @@ defmodule MeowNx.Utils do
   @doc """
   Given a 2-dimensional tensor replicates each row into
   two adjacent rows.
+
+  ## Examples
+
+      iex> t = Nx.tensor([[0, 0], [1, 1]])
+      iex> MeowNx.Utils.duplicate_rows(t)
+      #Nx.Tensor<
+        s64[4][2]
+        [
+          [0, 0],
+          [0, 0],
+          [1, 1],
+          [1, 1]
+        ]
+      >
   """
   defn duplicate_rows(t) do
     {n, m} = Nx.shape(t)
@@ -28,5 +56,29 @@ defmodule MeowNx.Utils do
     t
     |> Nx.tile([1, 2])
     |> Nx.reshape({twice_n, m})
+  end
+
+  @doc """
+  Returns the cumulative sum of elements in the given
+  1-dimensional tensor.
+
+  ## Examples
+
+      iex> MeowNx.Utils.cumulative_sum(Nx.tensor([1, 2, 3, 4]))
+      #Nx.Tensor<
+        s64[4]
+        [1, 3, 6, 10]
+      >
+  """
+  defn cumulative_sum(t) do
+    {n} = Nx.shape(t)
+    Nx.dot(lower_triangular(n), t)
+  end
+
+  defnp lower_triangular(n) do
+    Nx.less_equal(
+      Nx.iota({n, n}, axis: 1),
+      Nx.iota({n, n}, axis: 0)
+    )
   end
 end

--- a/test/meow_nx/utils_test.exs
+++ b/test/meow_nx/utils_test.exs
@@ -1,0 +1,5 @@
+defmodule MeowNx.UtilsTest do
+  use ExUnit.Case, async: true
+
+  doctest MeowNx.Utils
+end


### PR DESCRIPTION
Adds two new selection types, where individuals are selected randomly with probability proportional to their fitness (so that better individuals have higher chance of being chosen).

### Statistical verification

This simple test verifies the selection behaviour:

```elixir
genomes =
  Nx.tensor([
    [1, 1],
    [2, 2],
    [3, 3],
    [4, 4]
  ])

fitness = Nx.tensor([1, 2, 5, 2])

n = 10_000

{selected_genomes, _} = MeowNx.Selection.roulette_selection(genomes, fitness, n: n)
# {selected_genomes, _} = MeowNx.Selection.stochastic_universal_sampling(genomes, fitness, n: n)

selected_genomes
|> Nx.to_batched_list(1)
|> Enum.group_by(&Nx.to_flat_list/1)
|> Enum.map(fn {genome, group} -> {genome, length(group) / n} end)
|> Map.new()
```

For `roulette_selection`:

```elixir
%{[1, 1] => 0.0975, [2, 2] => 0.2025, [3, 3] => 0.4962, [4, 4] => 0.2038}
```

For `stochastic_universal_sampling` (similar approach, but with no bias):

```elixir
%{[1, 1] => 0.1, [2, 2] => 0.2, [3, 3] => 0.5, [4, 4] => 0.2}
```

So in both cases it's clear that individuals are selected with intensity proportional to their fitness.