### PR TITLE
Add support for distributed computation

### DIFF
--- a/examples/distributed.exs
+++ b/examples/distributed.exs
@@ -1,0 +1,65 @@
+# To test this locally, run the script in separate shell sessions.
+# Make sure to specify node name to enable distribution and pass
+# the expected CLI arguments like this:
+#
+#   elixir --name leader@127.0.0.1 examples/distributed.exs leader worker@127.0.0.1
+#
+#   elixir --name worker@127.0.0.1 examples/distributed.exs worker
+
+Mix.install([
+  {:meow, path: Path.expand("..", __DIR__)},
+  # or in a standalone script: {:meow, "~> 0.1.0-dev", github: "jonatanklosko/meow"},
+  {:nx, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "nx", override: true},
+  {:exla, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "exla"},
+  {:exla_precompiled, "~> 0.1.0-dev", github: "jonatanklosko/exla_precompiled"}
+])
+
+defmodule Problem do
+  import Nx.Defn
+
+  def size, do: 100
+
+  @two_pi 2 * :math.pi()
+
+  @defn_compiler EXLA
+  defn evaluate_rastrigin(genomes) do
+    sums =
+      (10 + Nx.power(genomes, 2) - 10 * Nx.cos(genomes * @two_pi))
+      |> Nx.sum(axes: [1])
+
+    -sums
+  end
+end
+
+alias Meow.{Model, Pipeline}
+
+model =
+  Model.new(
+    MeowNx.Init.real_random_uniform(100, Problem.size(), -5.12, 5.12),
+    &Problem.evaluate_rastrigin/1
+  )
+  |> Model.add_pipeline(
+    Pipeline.new([
+      MeowNx.Op.Selection.tournament(100),
+      MeowNx.Op.Crossover.uniform(0.5),
+      MeowNx.Op.Mutation.shift_gaussian(0.001),
+      Meow.Op.Multi.emigrate(
+        MeowNx.Op.Selection.tournament(5),
+        &Meow.Topology.ring/2,
+        interval: 10
+      ),
+      Meow.Op.Multi.immigrate(
+        &MeowNx.Op.Selection.natural(&1),
+        interval: 10
+      ),
+      MeowNx.Op.Metric.best_individual(),
+      Meow.Op.Termination.max_generations(1_000)
+    ]),
+    # Duplicate the pipeline, so that the model
+    # describes 4 populations
+    duplicate: 4
+  )
+
+Meow.Distribution.init_from_cli_args!(fn nodes ->
+  Meow.Runner.run(model, nodes: nodes)
+end)

--- a/lib/meow/distribution.ex
+++ b/lib/meow/distribution.ex
@@ -1,0 +1,209 @@
+defmodule Meow.Distribution do
+  @moduledoc """
+  Utilities for setting up and connecting runtime nodes.
+
+  When running the computation as a script you can use
+  `init_from_cli_args!/1` to easily configure the
+  distribution based on the CLI arguments. Otherwise the
+  underlying `init_leader/2` and `init_worker/1` are also
+  available.
+
+  Note that this module only provides conveniences and
+  configuration patterns, but you are free to setup and
+  connect the runtime nodes however you see fit. The core
+  APIs expect all relevant nodes to be already connected
+  and are agnostic to how it actually happens.
+  """
+
+  require Logger
+
+  @doc """
+  Initializes the runtime node based on the command line arguments.
+
+  Make sure to start the runtime in Erlang ditribution mode
+  by specifying node name.
+
+  Supports two combinations of arguments:
+
+    * `leader [worker_node] [worker_node] ...` - in this mode
+      the process establishes connection between all of the
+      listed worker nodes and then calls `leader_fun` passing
+      all nodes (including the leader) as an argument.
+
+    * `worker` - in this mode the process waits for the leader
+      to initiate the connection and start the relevant work.
+      The worker terminates as soon as the leader node terminates.
+
+  ## Options
+
+    * `:leader_opts` - see `init_leader/2` for available options
+
+    * `:worker_opts` - see `init_worker/1` for available options
+
+  ## Example
+
+  Start the leader node:
+
+      $ elixir --name leader@127.0.0.1 script.exs leader worker1@127.0.0.1 worker2@127.0.0.1
+
+  Start the worker nodes:
+
+      $ elixir --name worker1@127.0.0.1 script.exs worker
+
+      $ elixir --name worker2@127.0.0.1 script.exs worker
+
+  Where `script.exs` calls this function:
+
+      Meow.Distribution.init_from_cli_args!(fn nodes ->
+        # This runs on the leader node, once it successfully
+        # connects to all worker nodes
+      end)
+  """
+  @spec init_from_cli_args!((list(node()) -> any()), keyword()) :: :ok
+  def init_from_cli_args!(leader_fun, opts \\ []) do
+    validate_distribution!()
+
+    case System.argv() do
+      ["leader" | worker_nodes] ->
+        worker_nodes = Enum.map(worker_nodes, &String.to_atom/1)
+
+        leader_opts = opts[:leader_opts] || []
+        Meow.Distribution.init_leader(worker_nodes, leader_opts)
+
+        leader_fun.([node() | worker_nodes])
+
+      ["worker"] ->
+        worker_opts = opts[:worker_opts] || []
+        Meow.Distribution.init_worker(worker_opts)
+
+      args ->
+        raise RuntimeError, """
+        got unexpected CLI arguments: #{inspect(args)}
+
+        Expected one of the following:
+
+          leader [worker_node] [worker_node] ...
+
+          worker
+
+        See the documentation for more usage details\
+        """
+    end
+  end
+
+  @doc """
+  Enters leader mode.
+
+  Establishes connection to all of the given nodes and initiates
+  communication.
+
+  ## Options
+
+    * `:max_attempts` - the maximum number of connection attempts
+      to each node. Defaults to `60`.
+
+    * `:attempt_gap` - the number of milliseconds between
+      subsequent connection attempts. Defaults to `1_000`.
+  """
+  @spec init_leader(list(node()), keyword()) :: :ok
+  def init_leader(worker_nodes, opts \\ []) do
+    validate_distribution!()
+
+    max_attempts = opts[:max_attempts] || 60
+    attempt_gap = opts[:attempt_gap] || 1_000
+
+    initiate_workers(worker_nodes, [], max_attempts, attempt_gap)
+
+    Logger.info("Established connection with all worker nodes")
+
+    :ok
+  end
+
+  # Each node starts as disconnected, upon connection it
+  # becomes uninitiated, finally once we locate the worker
+  # process and send the init message it becomes initiated
+  defp initiate_workers(disconnected, uninitiated, attempts_left, attempt_gap)
+
+  defp initiate_workers(disconnected, uninitiated, 0, _attempt_gap) do
+    message =
+      [
+        "failed to establish connection to all worker within the given time limit",
+        if disconnected != [] do
+          "  * could not connect to the following nodes: #{Enum.join(disconnected, ", ")}"
+        end,
+        if uninitiated != [] do
+          "  * no worker process found on the following nodes: #{Enum.join(uninitiated, ", ")}"
+        end
+      ]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join("\n\n")
+
+    raise RuntimeError, message
+  end
+
+  defp initiate_workers(disconnected, uninitiated, attempts, attempt_gap) do
+    {new_connected, disconnected} = Enum.split_with(disconnected, &Node.connect/1)
+
+    {ready, uninitiated} =
+      Enum.split_with(new_connected ++ uninitiated, fn node ->
+        :global.whereis_name({node, :worker}) != :undefined
+      end)
+
+    for node <- ready do
+      :global.send({node, :worker}, {:initiate, node()})
+    end
+
+    if disconnected == [] and uninitiated == [] do
+      :ok
+    else
+      Process.sleep(attempt_gap)
+      initiate_workers(disconnected, uninitiated, attempts - 1, attempt_gap)
+    end
+  end
+
+  @doc """
+  Enters worker mode.
+
+  Waits for the leader node to initiate a connection, then
+  it starts monitoring this that and blocks until it terminates.
+
+  Raises `RuntimeError` if the initial message is not received
+  within the optional timeout.
+
+  ## Options
+
+    * `:timeout` - the maximum number of milliseconds to wait
+      for the leader node to initiate the connection. Defaults
+      to `60_000`.
+  """
+  @spec init_worker(keyword()) :: :ok
+  def init_worker(opts \\ []) do
+    validate_distribution!()
+
+    timeout = opts[:timeout] || 60_000
+
+    :global.register_name({node(), :worker}, self())
+
+    receive do
+      {:initiate, leader_node} ->
+        Logger.info("Established connection with the leader node (#{leader_node})")
+
+        Node.monitor(leader_node, true)
+
+        receive do
+          {:nodedown, ^leader_node} -> :ok
+        end
+    after
+      timeout ->
+        raise RuntimeError,
+              "expected to receive an initial message from the leader node within #{timeout}ms, but got none"
+    end
+  end
+
+  defp validate_distribution!() do
+    unless Node.alive?() do
+      raise RuntimeError,
+            "distribution mode hasn't been enabled, make sure to specify a node name when starting the runtime"
+    end
+  end
+end

--- a/lib/meow/distribution.ex
+++ b/lib/meow/distribution.ex
@@ -165,7 +165,7 @@ defmodule Meow.Distribution do
   Enters worker mode.
 
   Waits for the leader node to initiate a connection, then
-  it starts monitoring this that and blocks until it terminates.
+  starts monitoring this node and blocks until it terminates.
 
   Raises `RuntimeError` if the initial message is not received
   within the optional timeout.

--- a/lib/meow/runner.ex
+++ b/lib/meow/runner.ex
@@ -1,18 +1,57 @@
 defmodule Meow.Runner do
   @moduledoc """
-  A module responsible for running an evolutionary
-  algorithm, as defined by `Meow.Model`.
+  A module responsible for running an evolutionary algorithm,
+  as defined by `Meow.Model`.
   """
 
   alias Meow.{Population, Pipeline, Model}
 
   @doc """
-  Iteratively transforms populations according to
-  the given model until the populations are terminated.
+  Iteratively transforms populations according to the given
+  model until all populations are terminated.
+
+  ## Distribution
+
+  In case of a multi-population algorithm the populations
+  evolve in parallel, by default within the current runtime.
+
+  If multiple runtime nodes are available, the algorithm may
+  be run in a distributed setup by specifying the `:nodes`
+  option. In that case the populations are distributed among
+  said nodes, which can be further controlled with the
+  `:population_groups` option.
+
+  ## Options
+
+    * `:nodes` - a list of nodes available for running the
+      algorithm. Note that all of the nodes must already be
+      connected and all relevant modules must be available
+      for every node. Defaults to `[node()]`.
+
+    * `:population_groups` - a list of groups, where each
+      group is a list of population indices. Populations
+      from the same group will be run on the same node.
+      The number of groups should match the number of nodes
+      configured via `:nodes` and every population must be
+      in exactly one of the groups. By default populations
+      are split into even groups.
   """
-  @spec run(Model.t()) :: list(Population.t())
-  def run(model) do
-    {time, {times, populations}} = :timer.tc(&run_model/1, [model])
+  @spec run(Model.t(), keyword()) :: list(Population.t())
+  def run(model, opts \\ []) do
+    nodes = opts[:nodes] || [node()]
+    validate_nodes!(nodes)
+
+    number_of_nodes = length(nodes)
+    number_of_populations = length(model.pipelines)
+
+    population_groups =
+      Keyword.get_lazy(opts, :population_groups, fn ->
+        even_population_groups(number_of_populations, number_of_nodes)
+      end)
+
+    validate_population_groups!(population_groups, number_of_populations, number_of_nodes)
+
+    {time, {times, populations}} = :timer.tc(&run_model/3, [model, nodes, population_groups])
 
     IO.write([
       format_times(time, times),
@@ -22,12 +61,61 @@ defmodule Meow.Runner do
     populations
   end
 
-  defp run_model(model) do
+  defp validate_nodes!(nodes) do
+    if nodes == [] do
+      raise ArgumentError, "expected at least one node, but got an empty list"
+    end
+
+    case nodes -- [node() | Node.list()] do
+      [] ->
+        :ok
+
+      not_connected ->
+        raise ArgumentError,
+              "expected all nodes to be connected, but the following were not: #{Enum.join(not_connected, ", ")}"
+    end
+  end
+
+  defp validate_population_groups!(population_groups, number_of_populations, number_of_nodes) do
+    number_of_groups = length(population_groups)
+
+    if number_of_groups != number_of_nodes do
+      raise ArgumentError,
+            "expected the same number of population groups and nodes, but got different (#{number_of_groups} != #{number_of_nodes})"
+    end
+
+    indices = population_groups |> List.flatten() |> Enum.sort()
+    expected_indices = Enum.to_list(0..(number_of_populations - 1))
+
+    if indices != expected_indices do
+      raise ArgumentError,
+            "expected every population to be assigned to one of the population groups," <>
+              "\n  unexpected: #{inspect(indices -- expected_indices)}" <>
+              "\n  missing: #{inspect(expected_indices -- indices)}"
+    end
+  end
+
+  defp even_population_groups(number_of_populations, number_of_nodes) do
+    indices = Enum.to_list(0..(number_of_populations - 1))
+    Meow.Utils.split_evenly(indices, number_of_nodes)
+  end
+
+  defp run_model(model, nodes, population_groups) do
     runner_pid = self()
 
+    population_node_mapping =
+      for {node, indices} <- Enum.zip(nodes, population_groups),
+          idx <- indices,
+          into: %{},
+          do: {idx, node}
+
     pids =
-      Enum.map(model.pipelines, fn pipeline ->
-        spawn_link(fn ->
+      model.pipelines
+      |> Enum.with_index()
+      |> Enum.map(fn {pipeline, idx} ->
+        node = population_node_mapping[idx]
+
+        Node.spawn_link(node, fn ->
           {genomes, representation_spec} = model.initializer.()
           population = Population.new(genomes, representation_spec)
 

--- a/lib/meow/utils.ex
+++ b/lib/meow/utils.ex
@@ -1,0 +1,29 @@
+defmodule Meow.Utils do
+  @moduledoc false
+
+  @doc """
+  Distributes items evenly into the given number of chunks.
+
+  ## Examples
+
+      iex> Meow.Utils.split_evenly([1, 2, 3, 4], 2)
+      [[1, 2], [3, 4]]
+
+      iex> Meow.Utils.split_evenly([1, 2, 3, 4, 5, 6, 7], 3)
+      [[1, 2, 3], [4, 5], [6, 7]]
+
+      iex> Meow.Utils.split_evenly([1], 2)
+      [[1], []]
+  """
+  def split_evenly(list, number_of_chunks) do
+    split_evenly(list, number_of_chunks, [])
+  end
+
+  defp split_evenly([], 0, acc), do: Enum.reverse(acc)
+
+  defp split_evenly(list, number_of_chunks, acc) do
+    chunk_size = ceil(length(list) / number_of_chunks)
+    {group, rest} = Enum.split(list, chunk_size)
+    split_evenly(rest, number_of_chunks - 1, [group | acc])
+  end
+end

--- a/test/meow/utils_test.exs
+++ b/test/meow/utils_test.exs
@@ -1,0 +1,5 @@
+defmodule Meow.UtilsTest do
+  use ExUnit.Case, async: true
+
+  doctest Meow.Utils
+end


### PR DESCRIPTION
This extends `Meow.Runner` to accept a list of distribution nodes and split populations among those nodes. All the communication (specifically migration) stays unchanged, since populations are already process based.

The runner assumes the nodes are already set up and connected and is agnostic to how it is done. Consequently, I added `Meow.Distribution` with a number o utility functions for setting up distribution. Notably, switching Elixir scripts (as in our examples) to handle distribution is as simple as:

```diff
- Meow.Runner.run(model)
+ Meow.Distribution.init_from_cli_args!(fn nodes ->
+  Meow.Runner.run(model, nodes: nodes)
+ end)
```

With this change, the script can be run either in leader or worker mode, which gets configured via CLI arguments.

### Example

https://user-images.githubusercontent.com/17034772/131587246-b1ded2a6-3a5f-4fce-bab3-7523bd90be43.mp4