### PR TITLE
Support relative selection size

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ model =
     # A single pipeline corresponds to a single population
     Pipeline.new([
       # Define a number of evolutionary steps that the population goes through
-      MeowNx.Op.Selection.tournament(100),
+      MeowNx.Op.Selection.tournament(1.0),
       MeowNx.Op.Crossover.uniform(0.5),
       MeowNx.Op.Mutation.replace_uniform(0.001, -5.12, 5.12),
       MeowNx.Op.Metric.best_individual(),

--- a/examples/distributed.exs
+++ b/examples/distributed.exs
@@ -40,7 +40,7 @@ model =
   )
   |> Model.add_pipeline(
     Pipeline.new([
-      MeowNx.Op.Selection.tournament(100),
+      MeowNx.Op.Selection.tournament(1.0),
       MeowNx.Op.Crossover.uniform(0.5),
       MeowNx.Op.Mutation.shift_gaussian(0.001),
       Meow.Op.Multi.emigrate(

--- a/examples/intro.exs
+++ b/examples/intro.exs
@@ -42,7 +42,7 @@ model =
     # A single pipeline corresponds to a single population
     Pipeline.new([
       # Define a number of evolutionary steps that the population goes through
-      MeowNx.Op.Selection.tournament(100),
+      MeowNx.Op.Selection.tournament(1.0),
       MeowNx.Op.Crossover.uniform(0.5),
       MeowNx.Op.Mutation.replace_uniform(0.001, -5.12, 5.12),
       MeowNx.Op.Metric.best_individual(),

--- a/examples/knapsack.exs
+++ b/examples/knapsack.exs
@@ -43,7 +43,7 @@ model =
   )
   |> Model.add_pipeline(
     Pipeline.new([
-      MeowNx.Op.Selection.tournament(100),
+      MeowNx.Op.Selection.tournament(1.0),
       MeowNx.Op.Crossover.uniform(0.5),
       MeowNx.Op.Mutation.binary_replace_uniform(0.1),
       MeowNx.Op.Metric.best_individual(),

--- a/examples/one_max.exs
+++ b/examples/one_max.exs
@@ -29,7 +29,7 @@ model =
   )
   |> Model.add_pipeline(
     Pipeline.new([
-      MeowNx.Op.Selection.tournament(100),
+      MeowNx.Op.Selection.tournament(1.0),
       MeowNx.Op.Crossover.uniform(0.5),
       MeowNx.Op.Mutation.binary_replace_uniform(0.001),
       MeowNx.Op.Metric.best_individual(),

--- a/examples/rastrigin.exs
+++ b/examples/rastrigin.exs
@@ -35,7 +35,7 @@ defmodule Rastrigin do
     )
     |> Model.add_pipeline(
       Pipeline.new([
-        Selection.tournament(100),
+        Selection.tournament(1.0),
         Crossover.uniform(0.5),
         Mutation.replace_uniform(0.001, -5.12, 5.12),
         Metric.best_individual(),
@@ -51,7 +51,7 @@ defmodule Rastrigin do
     )
     |> Model.add_pipeline(
       Pipeline.new([
-        Selection.tournament(100),
+        Selection.tournament(1.0),
         Crossover.uniform(0.5),
         Mutation.shift_gaussian(0.001),
         Multi.emigrate(Selection.tournament(5), &Topology.ring/2, interval: 10),
@@ -76,10 +76,10 @@ defmodule Rastrigin do
           &Population.duplicate(&1, 2),
           [
             Pipeline.new([
-              Selection.natural(20)
+              Selection.natural(0.2)
             ]),
             Pipeline.new([
-              Selection.tournament(80),
+              Selection.tournament(0.8),
               Crossover.blend_alpha(0.5),
               Mutation.shift_gaussian(0.001)
             ])

--- a/notebooks/rastrigin_intro.livemd
+++ b/notebooks/rastrigin_intro.livemd
@@ -102,7 +102,7 @@ model =
     # A single pipeline corresponds to a single population
     Pipeline.new([
       # Define a number of evolutionary steps that the population goes through
-      Selection.tournament(100),
+      Selection.tournament(1.0),
       Crossover.uniform(0.5),
       Mutation.replace_uniform(0.001, -5.12, 5.12),
       Metric.best_individual(),
@@ -151,10 +151,10 @@ model =
         &Population.duplicate(&1, 2),
         [
           Pipeline.new([
-            Selection.natural(20)
+            Selection.natural(0.2)
           ]),
           Pipeline.new([
-            Selection.tournament(80),
+            Selection.tournament(0.8),
             Crossover.blend_alpha(0.5),
             Mutation.shift_gaussian(0.001)
           ])
@@ -200,7 +200,7 @@ model =
   )
   |> Model.add_pipeline(
     Pipeline.new([
-      Selection.tournament(100),
+      Selection.tournament(1.0),
       Crossover.uniform(0.5),
       Mutation.shift_gaussian(0.001),
       Multi.emigrate(Selection.natural(5), &Topology.ring/2, interval: 10),


### PR DESCRIPTION
For selection operations it's usually much more convenient to specify selection size as a fraction of the population, rather than an absolute size. This way if the user changes the population size, they don't have to remember about adjusting the selection size.