### PR TITLE
Make Nx.Defn.jit/3 options configurable

### DIFF
--- a/lib/meow/op/context.ex
+++ b/lib/meow/op/context.ex
@@ -5,12 +5,13 @@ defmodule Meow.Op.Context do
   population.
   """
 
-  defstruct [:evaluate, :population_pids]
+  defstruct [:evaluate, :population_pids, :global_opts]
 
   alias Meow.Model
 
   @type t :: %__MODULE__{
           evaluate: Model.evaluate(),
-          population_pids: list(pid())
+          population_pids: list(pid()),
+          global_opts: keyword()
         }
 end

--- a/lib/meow_nx.ex
+++ b/lib/meow_nx.ex
@@ -16,5 +16,15 @@ defmodule MeowNx do
 
   `MeowNx` provides a number of numerical definitions,
   as well as `Meow` operation definitions on top of that.
+
+  ## Configuration
+
+  When running a model using `MeoxNx` operations the following
+  global options are available (passed to runner):
+
+    * `:jit_opts` - options passed to `Nx.Defn.jit` when
+      compiling the underlying numerical definitions. This
+      defaults to `[compiler: EXLA]` if `exla` is available,
+      and to `[]` otherwise.
   """
 end

--- a/lib/meow_nx/op/crossover.ex
+++ b/lib/meow_nx/op/crossover.ex
@@ -9,6 +9,7 @@ defmodule MeowNx.Op.Crossover do
 
   alias Meow.Op
   alias MeowNx.Crossover
+  alias MeowNx.Utils
 
   @doc """
   Builds a uniform crossover operation.
@@ -23,11 +24,9 @@ defmodule MeowNx.Op.Crossover do
       name: "[Nx] Uniform crossover",
       requires_fitness: false,
       invalidates_fitness: true,
-      impl: fn population, _ctx ->
+      impl: fn population, ctx ->
         Op.map_genomes(population, fn genomes ->
-          # TODO: make compiler (and generally other options)
-          # configurable globally for the model
-          Nx.Defn.jit(&Crossover.uniform(&1, opts), [genomes], compiler: EXLA)
+          Nx.Defn.jit(&Crossover.uniform(&1, opts), [genomes], Utils.jit_opts(ctx))
         end)
       end
     }
@@ -44,11 +43,9 @@ defmodule MeowNx.Op.Crossover do
       name: "[Nx] Single point crossover",
       requires_fitness: false,
       invalidates_fitness: true,
-      impl: fn population, _ctx ->
+      impl: fn population, ctx ->
         Op.map_genomes(population, fn genomes ->
-          # TODO: make compiler (and generally other options)
-          # configurable globally for the model
-          Nx.Defn.jit(&Crossover.single_point(&1), [genomes], compiler: EXLA)
+          Nx.Defn.jit(&Crossover.single_point(&1), [genomes], Utils.jit_opts(ctx))
         end)
       end
     }
@@ -67,11 +64,9 @@ defmodule MeowNx.Op.Crossover do
       name: "[Nx] Blend-alpha crossover",
       requires_fitness: false,
       invalidates_fitness: true,
-      impl: fn population, _ctx ->
+      impl: fn population, ctx ->
         Op.map_genomes(population, fn genomes ->
-          # TODO: make compiler (and generally other options)
-          # configurable globally for the model
-          Nx.Defn.jit(&Crossover.blend_alpha(&1, opts), [genomes], compiler: EXLA)
+          Nx.Defn.jit(&Crossover.blend_alpha(&1, opts), [genomes], Utils.jit_opts(ctx))
         end)
       end
     }
@@ -90,11 +85,9 @@ defmodule MeowNx.Op.Crossover do
       name: "[Nx] Simulated binary crossover",
       requires_fitness: false,
       invalidates_fitness: true,
-      impl: fn population, _ctx ->
+      impl: fn population, ctx ->
         Op.map_genomes(population, fn genomes ->
-          # TODO: make compiler (and generally other options)
-          # configurable globally for the model
-          Nx.Defn.jit(&Crossover.simulated_binary(&1, opts), [genomes], compiler: EXLA)
+          Nx.Defn.jit(&Crossover.simulated_binary(&1, opts), [genomes], Utils.jit_opts(ctx))
         end)
       end
     }

--- a/lib/meow_nx/op/metric.ex
+++ b/lib/meow_nx/op/metric.ex
@@ -9,6 +9,7 @@ defmodule MeowNx.Op.Metric do
 
   alias Meow.Op
   alias MeowNx.Metric
+  alias MeowNx.Utils
 
   @doc """
   Builds a metric operation loging the best individual.
@@ -21,12 +22,12 @@ defmodule MeowNx.Op.Metric do
       name: "Metric: best individual",
       requires_fitness: true,
       invalidates_fitness: false,
-      impl: fn population, _ctx ->
-        # TODO: make compiler (and generally other options)
-        # configurable globally for the model
+      impl: fn population, ctx ->
         {best_genome, best_fitness} =
-          Nx.Defn.jit(&Metric.best_individual/2, [population.genomes, population.fitness],
-            compiler: EXLA
+          Nx.Defn.jit(
+            &Metric.best_individual/2,
+            [population.genomes, population.fitness],
+            Utils.jit_opts(ctx)
           )
 
         best_individual = %{

--- a/lib/meow_nx/op/mutation.ex
+++ b/lib/meow_nx/op/mutation.ex
@@ -9,6 +9,7 @@ defmodule MeowNx.Op.Mutation do
 
   alias Meow.Op
   alias MeowNx.Mutation
+  alias MeowNx.Utils
 
   @doc """
   Builds a uniform replacement mutation operation.
@@ -23,9 +24,9 @@ defmodule MeowNx.Op.Mutation do
       name: "[Nx] Mutation replace uniform",
       requires_fitness: false,
       invalidates_fitness: true,
-      impl: fn population, _ctx ->
+      impl: fn population, ctx ->
         Op.map_genomes(population, fn genomes ->
-          Nx.Defn.jit(&Mutation.replace_uniform(&1, opts), [genomes], compiler: EXLA)
+          Nx.Defn.jit(&Mutation.replace_uniform(&1, opts), [genomes], Utils.jit_opts(ctx))
         end)
       end
     }
@@ -45,9 +46,9 @@ defmodule MeowNx.Op.Mutation do
       name: "[Nx] Mutation replace uniform",
       requires_fitness: false,
       invalidates_fitness: true,
-      impl: fn population, _ctx ->
+      impl: fn population, ctx ->
         Op.map_genomes(population, fn genomes ->
-          Nx.Defn.jit(&Mutation.binary_replace_uniform(&1, opts), [genomes], compiler: EXLA)
+          Nx.Defn.jit(&Mutation.binary_replace_uniform(&1, opts), [genomes], Utils.jit_opts(ctx))
         end)
       end
     }
@@ -66,9 +67,9 @@ defmodule MeowNx.Op.Mutation do
       name: "[Nx] Mutation shift Gaussian",
       requires_fitness: false,
       invalidates_fitness: true,
-      impl: fn population, _ctx ->
+      impl: fn population, ctx ->
         Op.map_genomes(population, fn genomes ->
-          Nx.Defn.jit(&Mutation.shift_gaussian(&1, opts), [genomes], compiler: EXLA)
+          Nx.Defn.jit(&Mutation.shift_gaussian(&1, opts), [genomes], Utils.jit_opts(ctx))
         end)
       end
     }

--- a/lib/meow_nx/op/selection.ex
+++ b/lib/meow_nx/op/selection.ex
@@ -9,6 +9,7 @@ defmodule MeowNx.Op.Selection do
 
   alias Meow.Op
   alias MeowNx.Selection
+  alias MeowNx.Utils
 
   @doc """
   Builds a tournament selection operation.
@@ -23,9 +24,13 @@ defmodule MeowNx.Op.Selection do
       name: "[Nx] Selection tournament",
       requires_fitness: true,
       invalidates_fitness: false,
-      impl: fn population, _ctx ->
+      impl: fn population, ctx ->
         Op.map_genomes_and_fitness(population, fn genomes, fitness ->
-          Nx.Defn.jit(&Selection.tournament(&1, &2, opts), [genomes, fitness], compiler: EXLA)
+          Nx.Defn.jit(
+            &Selection.tournament(&1, &2, opts),
+            [genomes, fitness],
+            Utils.jit_opts(ctx)
+          )
         end)
       end
     }
@@ -44,9 +49,9 @@ defmodule MeowNx.Op.Selection do
       name: "[Nx] Selection natural",
       requires_fitness: true,
       invalidates_fitness: false,
-      impl: fn population, _ctx ->
+      impl: fn population, ctx ->
         Op.map_genomes_and_fitness(population, fn genomes, fitness ->
-          Nx.Defn.jit(&Selection.natural(&1, &2, opts), [genomes, fitness], compiler: EXLA)
+          Nx.Defn.jit(&Selection.natural(&1, &2, opts), [genomes, fitness], Utils.jit_opts(ctx))
         end)
       end
     }

--- a/lib/meow_nx/utils.ex
+++ b/lib/meow_nx/utils.ex
@@ -81,4 +81,23 @@ defmodule MeowNx.Utils do
       Nx.iota({n, n}, axis: 0)
     )
   end
+
+  # Other
+
+  @doc """
+  Returns `Nx.Defn.jit/3` options based on the global
+  configuration in context.
+  """
+  @spec jit_opts(Meow.Op.Context.t()) :: keyword()
+  def jit_opts(ctx) do
+    if opts = ctx.global_opts[:jit_opts] do
+      opts
+    else
+      if Code.ensure_loaded?(EXLA) do
+        [compiler: EXLA]
+      else
+        []
+      end
+    end
+  end
 end


### PR DESCRIPTION
Removes the hardcoded `Nx.Defn.jit/3` options and allows configuration via "global options" like this: `Meow.Runner.run(model, global_opts: [jit_opts: [compiler: EXLA, ...]])`. I'm not sure if this is intuitive enough, but we can always revisit this later. Also, we still default to `[compiler: EXLA]` if `exla` is available, so this doesn't change the current usage.