### PR TITLE
Make initialization into a regular operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ alias Meow.{Model, Pipeline}
 model =
   Model.new(
     # Define how the population is initialized and what representation to use
-    MeowNx.Init.real_random_uniform(100, Problem.size(), -5.12, 5.12),
+    MeowNx.Op.Init.real_random_uniform(100, Problem.size(), -5.12, 5.12),
     # Specify the evaluation function that we are trying to maximise
     &Problem.evaluate_rastrigin/1
   )

--- a/examples/distributed.exs
+++ b/examples/distributed.exs
@@ -35,7 +35,7 @@ alias Meow.{Model, Pipeline}
 
 model =
   Model.new(
-    MeowNx.Init.real_random_uniform(100, Problem.size(), -5.12, 5.12),
+    MeowNx.Op.Init.real_random_uniform(100, Problem.size(), -5.12, 5.12),
     &Problem.evaluate_rastrigin/1
   )
   |> Model.add_pipeline(

--- a/examples/intro.exs
+++ b/examples/intro.exs
@@ -34,7 +34,7 @@ alias Meow.{Model, Pipeline}
 model =
   Model.new(
     # Define how the population is initialized and what representation to use
-    MeowNx.Init.real_random_uniform(100, Problem.size(), -5.12, 5.12),
+    MeowNx.Op.Init.real_random_uniform(100, Problem.size(), -5.12, 5.12),
     # Specify the evaluation function that we are trying to maximise
     &Problem.evaluate_rastrigin/1
   )

--- a/examples/knapsack.exs
+++ b/examples/knapsack.exs
@@ -38,7 +38,7 @@ alias Meow.{Model, Pipeline}
 
 model =
   Model.new(
-    MeowNx.Init.binary_random_uniform(100, Problem.size()),
+    MeowNx.Op.Init.binary_random_uniform(100, Problem.size()),
     &Problem.evaluate_knapsack/1
   )
   |> Model.add_pipeline(

--- a/examples/one_max.exs
+++ b/examples/one_max.exs
@@ -24,7 +24,7 @@ alias Meow.{Model, Pipeline}
 
 model =
   Model.new(
-    MeowNx.Init.binary_random_uniform(100, Problem.size()),
+    MeowNx.Op.Init.binary_random_uniform(100, Problem.size()),
     &Problem.evaluate_one_max/1
   )
   |> Model.add_pipeline(

--- a/examples/rastrigin.exs
+++ b/examples/rastrigin.exs
@@ -12,8 +12,7 @@ defmodule Rastrigin do
   import Nx.Defn
   alias Meow.{Model, Pipeline, Population, Topology}
   alias Meow.Op.{Termination, Flow, Multi}
-  alias MeowNx.Init
-  alias MeowNx.Op.{Selection, Crossover, Mutation, Metric}
+  alias MeowNx.Op.{Init, Selection, Crossover, Mutation, Metric}
 
   def size, do: 100
 

--- a/lib/meow/model.ex
+++ b/lib/meow/model.ex
@@ -5,19 +5,13 @@ defmodule Meow.Model do
 
   defstruct [:initializer, :evaluate, pipelines: []]
 
-  alias Meow.{Population, Pipeline}
+  alias Meow.{Population, Pipeline, Op}
 
   @type t :: %__MODULE__{
-          initializer: initializer(),
+          initializer: Op.t(),
           evaluate: evaluate(),
           pipelines: list(Pipeline.t())
         }
-
-  @typedoc """
-  A function used to generate initial genomes according
-  to the chosen representation.
-  """
-  @type initializer :: (() -> {Population.genomes(), representation_spec :: module()})
 
   @typedoc """
   A function used to calculate the assessment of all
@@ -34,7 +28,7 @@ defmodule Meow.Model do
   @doc """
   Entrypoint for building a new model definition.
   """
-  @spec new(initializer(), evaluate()) :: t()
+  @spec new(Op.t(), evaluate()) :: t()
   def new(initializer, evaluate) do
     %__MODULE__{initializer: initializer, evaluate: evaluate}
   end

--- a/lib/meow_nx/init.ex
+++ b/lib/meow_nx/init.ex
@@ -1,18 +1,28 @@
 defmodule MeowNx.Init do
   @moduledoc """
-  Genomes initializers for the tensor representation.
+  Numerical implementations of common initializations.
+
+  Initialization refers to the operation of generating
+  a population of individuals, generally in a random way.
   """
 
   import Nx.Defn
 
-  def real_random_uniform(n, length, min, max) do
-    fn ->
-      genomes = real_random_uniform_impl(n: n, length: length, min: min, max: max)
-      {genomes, MeowNx.RepresentationSpec}
-    end
-  end
+  @doc """
+  Generates a population, where each genome is represented
+  by a series of real numbers.
 
-  defn real_random_uniform_impl(opts \\ []) do
+  ## Options
+
+    * `:n` - the number of individuals to generate. Required.
+
+    * `:length` - the length of a single genome. Required.
+
+    * `:min` - the minimum possible value of a gene. Required.
+
+    * `:max` - the maximum possible value of a gene. Required.
+  """
+  defn real_random_uniform(opts \\ []) do
     opts = keyword!(opts, [:n, :length, :min, :max])
     n = opts[:n]
     length = opts[:length]
@@ -22,14 +32,17 @@ defmodule MeowNx.Init do
     Nx.random_uniform({n, length}, min, max)
   end
 
-  def binary_random_uniform(n, length) do
-    fn ->
-      genomes = binary_random_uniform_impl(n: n, length: length)
-      {genomes, MeowNx.RepresentationSpec}
-    end
-  end
+  @doc """
+  Generates a population, where each genome is a series of
+  zeros and ones, or in other words a binary string.
 
-  defn binary_random_uniform_impl(opts \\ []) do
+  ## Options
+
+    * `:n` - the number of individuals to generate. Required.
+
+    * `:length` - the length of a single genome. Required.
+  """
+  defn binary_random_uniform(opts \\ []) do
     opts = keyword!(opts, [:n, :length])
     n = opts[:n]
     length = opts[:length]

--- a/lib/meow_nx/op/init.ex
+++ b/lib/meow_nx/op/init.ex
@@ -1,0 +1,55 @@
+defmodule MeowNx.Op.Init do
+  @moduledoc """
+  Initialization operations backed by numerical definitions.
+
+  This module provides a compatibility layer for `Meow`,
+  while individual numerical definitions can be found
+  in `MeowNx.Init`.
+  """
+
+  alias Meow.Op
+  alias MeowNx.Init
+  alias MeowNx.Utils
+
+  @doc """
+  Builds a random initialization operation for the real
+  representation.
+
+  See `MeowNx.Init.real_random_uniform/1` for more details.
+  """
+  @spec real_random_uniform(non_neg_integer(), non_neg_integer(), float(), float()) :: Op.t()
+  def real_random_uniform(n, length, min, max) do
+    opts = [n: n, length: length, min: min, max: max]
+
+    %Op{
+      name: "[Nx] Initialization random uniform",
+      requires_fitness: false,
+      invalidates_fitness: true,
+      impl: fn population, ctx ->
+        genomes = Nx.Defn.jit(fn -> Init.real_random_uniform(opts) end, [], Utils.jit_opts(ctx))
+        %{population | genomes: genomes, representation_spec: MeowNx.RepresentationSpec}
+      end
+    }
+  end
+
+  @doc """
+  Builds a random initialization operation for the binary
+  representation.
+
+  See `MeowNx.Init.binary_random_uniform/1` for more details.
+  """
+  @spec binary_random_uniform(non_neg_integer(), non_neg_integer()) :: Op.t()
+  def binary_random_uniform(n, length) do
+    opts = [n: n, length: length]
+
+    %Op{
+      name: "[Nx] Initialization random uniform",
+      requires_fitness: false,
+      invalidates_fitness: true,
+      impl: fn population, ctx ->
+        genomes = Nx.Defn.jit(fn -> Init.binary_random_uniform(opts) end, [], Utils.jit_opts(ctx))
+        %{population | genomes: genomes, representation_spec: MeowNx.RepresentationSpec}
+      end
+    }
+  end
+end

--- a/notebooks/rastrigin_intro.livemd
+++ b/notebooks/rastrigin_intro.livemd
@@ -22,8 +22,7 @@ Let's also add some aliases to make the algorithm definitions less verbose.
 alias Meow.{Model, Pipeline, Population, Topology}
 alias Meow.Op.{Termination, Flow, Multi}
 # We are going to use the Nx Meow integration
-alias MeowNx.Init
-alias MeowNx.Op.{Selection, Crossover, Mutation, Metric}
+alias MeowNx.Op.{Init, Selection, Crossover, Mutation, Metric}
 ```
 
 ## Objective


### PR DESCRIPTION
Makes the initializer an operation that takes an empty population and generates the genomes. This makes it more in line with the other elements. Also, this way the defn can be easily compiled with EXLA as other operations. Finally, this should make it possible to use the initializer in other places of the pipeline (for example to introduce some entirely new random individuals every once in a while).