### PR TITLE
Add validations around matching representation

### DIFF
--- a/lib/meow/op.ex
+++ b/lib/meow/op.ex
@@ -11,9 +11,22 @@ defmodule Meow.Op do
   of the operation.
   """
 
-  @enforce_keys [:name, :impl, :requires_fitness, :invalidates_fitness]
+  @enforce_keys [
+    :name,
+    :impl,
+    :requires_fitness,
+    :invalidates_fitness,
+    :in_representations
+  ]
 
-  defstruct [:name, :impl, :requires_fitness, :invalidates_fitness]
+  defstruct [
+    :name,
+    :impl,
+    :requires_fitness,
+    :invalidates_fitness,
+    :in_representations,
+    out_representation: :same
+  ]
 
   alias Meow.{Population, Op}
 
@@ -21,7 +34,9 @@ defmodule Meow.Op do
           name: String.t(),
           impl: (Population.t(), Op.Context.t() -> Population.t()),
           requires_fitness: boolean(),
-          invalidates_fitness: boolean()
+          invalidates_fitness: boolean(),
+          in_representations: :any | list(Population.representation()),
+          out_representation: :same | Population.representation()
         }
 
   @doc """
@@ -36,7 +51,12 @@ defmodule Meow.Op do
   end
 
   def apply(population, operation, ctx) do
-    operation.impl.(population, ctx)
+    new_population = operation.impl.(population, ctx)
+
+    case operation.out_representation do
+      :same -> new_population
+      representation -> %{new_population | representation: representation}
+    end
   end
 
   # Helpers to use when building custom operations

--- a/lib/meow_nx/crossover.ex
+++ b/lib/meow_nx/crossover.ex
@@ -73,7 +73,7 @@ defmodule MeowNx.Crossover do
     # Generate n / 2 split points (like [5, 2, 3]), and replicate
     # them for adjacent parents (like [5, 5, 2, 2, 3, 3])
     split_idx =
-      Nx.random_uniform({half_n, 1}, 1, n - 1)
+      Nx.random_uniform({half_n, 1}, 1, length - 1)
       |> Utils.duplicate_rows()
 
     swap? = Nx.iota({1, length}) |> Nx.less_equal(split_idx)
@@ -114,7 +114,7 @@ defmodule MeowNx.Crossover do
     * [Multiobjective Evolutionary Algorithms forElectric Power Dispatch Problem](https://www.researchgate.net/figure/Blend-crossover-operator-BLX_fig1_226044085), Fig. 1.
   """
   defn blend_alpha(parents, opts \\ []) do
-    opts = keyword!(opts, [:alpha])
+    opts = keyword!(opts, alpha: 0.5)
     alpha = opts[:alpha]
 
     {n, length} = Nx.shape(parents)

--- a/test/meow/model_test.exs
+++ b/test/meow/model_test.exs
@@ -1,0 +1,67 @@
+defmodule Meow.ModelTest do
+  use ExUnit.Case, async: true
+
+  alias Meow.{Model, Op, Pipeline}
+
+  describe "add_pipeline/4" do
+    test "raises an error when initializer operation doesn't have explicit output representation" do
+      model = Model.new(fn _, _ -> :ok end)
+
+      non_initializer = %Op{
+        name: "Non-initializer",
+        requires_fitness: false,
+        invalidates_fitness: true,
+        in_representations: :any,
+        out_representation: :same,
+        impl: fn population, _ctx -> population end
+      }
+
+      assert_raise ArgumentError,
+                   ~s/expected an initializer operation, got: "Non-initializer"/,
+                   fn ->
+                     Model.add_pipeline(model, non_initializer, Pipeline.new([]))
+                   end
+    end
+
+    test "raises an error on representation mismatch within the pipeline" do
+      model = Model.new(fn _, _ -> :ok end)
+
+      real_initializer = %Op{
+        name: "Real initializer",
+        requires_fitness: false,
+        invalidates_fitness: true,
+        in_representations: :any,
+        out_representation: {Meow.TestRepresentationSpec, :real},
+        impl: fn population, _ctx -> population end
+      }
+
+      real_selection = %Op{
+        name: "Real selection",
+        requires_fitness: true,
+        invalidates_fitness: false,
+        in_representations: [{Meow.TestRepresentationSpec, :real}],
+        out_representation: :same,
+        impl: fn population, _ctx -> population end
+      }
+
+      binary_crossover = %Op{
+        name: "Binary crossover",
+        requires_fitness: false,
+        invalidates_fitness: true,
+        in_representations: [{Meow.TestRepresentationSpec, :binary}],
+        out_representation: :same,
+        impl: fn population, _ctx -> population end
+      }
+
+      assert_raise ArgumentError,
+                   ~s/representation mismatch, "Binary crossover" does not accept {Meow.TestRepresentationSpec, :real}/,
+                   fn ->
+                     Model.add_pipeline(
+                       model,
+                       real_initializer,
+                       Pipeline.new([real_selection, binary_crossover])
+                     )
+                   end
+    end
+  end
+end

--- a/test/support/test_representation_spec.ex
+++ b/test/support/test_representation_spec.ex
@@ -1,0 +1,14 @@
+defmodule Meow.TestRepresentationSpec do
+  @moduledoc false
+
+  @behaviour Meow.RepresentationSpec
+
+  @impl true
+  def population_size(genomes), do: length(genomes)
+
+  @impl true
+  def concatenate_genomes(genomes_list), do: Enum.concat(genomes_list)
+
+  @impl true
+  def concatenate_fitness(fitness_list), do: Enum.concat(fitness_list)
+end


### PR DESCRIPTION
Currently if the user uses incompatible operations within the model, it at best fails once the algorithm starts evaluating. This extends operation definitions to explicitly list supported inputs and output, so we can validate the model upfront.

We have `RepresentationSpec` for describing basic data characteristics, but the same spec is likely applicable for multiple representations. For example `MeowNx.RepresentationSpec` would be the same for real, binary and probably any other Nx-based representation. Consequently, I adjusted representation to be a tuple like `{MeowNx.RepresentationSpec, :real}`.