### PR TITLE
Implement multi-point crossover

### DIFF
--- a/examples/knapsack.exs
+++ b/examples/knapsack.exs
@@ -41,7 +41,7 @@ model =
     MeowNx.Ops.init_binary_random_uniform(100, Problem.size()),
     Pipeline.new([
       MeowNx.Ops.selection_tournament(1.0),
-      MeowNx.Ops.crossover_uniform(0.5),
+      MeowNx.Ops.crossover_multi_point(3),
       MeowNx.Ops.mutation_bit_flip(0.1),
       MeowNx.Ops.metric_best_individual(),
       Meow.Ops.max_generations(100)

--- a/lib/meow_nx/ops.ex
+++ b/lib/meow_nx/ops.ex
@@ -208,6 +208,29 @@ defmodule MeowNx.Ops do
   end
 
   @doc """
+  Builds a multi point crossover operation.
+
+  See `MeowNx.Crossover.multi_point/1` for more details.
+  """
+  @doc type: :crossover
+  @spec crossover_multi_point(pos_integer()) :: Op.t()
+  def crossover_multi_point(points) do
+    opts = [points: points]
+
+    %Op{
+      name: "[Nx] Crossover: multi point",
+      requires_fitness: false,
+      invalidates_fitness: true,
+      in_representations: @representations,
+      impl: fn population, ctx ->
+        Op.map_genomes(population, fn genomes ->
+          Nx.Defn.jit(&Crossover.multi_point(&1, opts), [genomes], Utils.jit_opts(ctx))
+        end)
+      end
+    }
+  end
+
+  @doc """
   Builds a blend-alpha crossover operation.
 
   See `MeowNx.Crossover.blend_alpha/2` for more details.

--- a/lib/meow_nx/utils.ex
+++ b/lib/meow_nx/utils.ex
@@ -82,6 +82,34 @@ defmodule MeowNx.Utils do
     )
   end
 
+  @doc """
+  Returns a tensor of random indices on the interval `[:min, :max)`
+  without replacement (repetitions).
+
+  The resulting tensor has `:shape` with random indices `:axis`.
+  """
+  defn random_idx_without_replacement(opts \\ []) do
+    opts = keyword!(opts, [:shape, :min, :max, :axis])
+    shape = opts[:shape]
+    min = opts[:min]
+    max = opts[:max]
+    axis = opts[:axis]
+
+    # We use argsort on random numbers to generate shuffled indices
+    # and then we slice them according to the sample size
+
+    range = max - min
+
+    sample_size = transform(shape, &elem(&1, axis))
+    random_shape = transform(shape, &put_elem(&1, axis, range))
+
+    random_shape
+    |> Nx.random_uniform()
+    |> Nx.argsort(axis: axis)
+    |> Nx.slice_axis(0, sample_size, axis)
+    |> Nx.add(min)
+  end
+
   # Macros for use in defn
 
   @doc """

--- a/test/meow_nx/crossover_test.exs
+++ b/test/meow_nx/crossover_test.exs
@@ -1,0 +1,50 @@
+defmodule MeowNx.CrossoverTest do
+  use ExUnit.Case, async: true
+
+  alias MeowNx.Crossover
+
+  describe "multi_point/2" do
+    test "raises an error when too many points are specified" do
+      genomes = Nx.tensor([[1, 2], [1, 2]])
+
+      assert_raise ArgumentError, "2-point crossover is not valid for genome of length 2", fn ->
+        Crossover.multi_point(genomes, points: 2)
+      end
+    end
+
+    test "deterministic case where every second gene is swapped (points == length - 1)" do
+      genomes =
+        Nx.tensor([
+          [1, 2, 3, 4],
+          [-1, -2, -3, -4],
+          [11, 22, 33, 44],
+          [-11, -22, -33, -44]
+        ])
+
+      assert Crossover.multi_point(genomes, points: 3) ==
+               Nx.tensor([
+                 [1, -2, 3, -4],
+                 [-1, 2, -3, 4],
+                 [11, -22, 33, -44],
+                 [-11, 22, -33, 44]
+               ])
+    end
+
+    test "property: the number of crossover points matches the specified one" do
+      genomes = Nx.random_uniform({100, 100})
+      points = 10
+
+      offsprings = Crossover.multi_point(genomes, points: points)
+
+      same_gene? = Nx.equal(genomes, offsprings)
+
+      number_of_points =
+        same_gene?
+        |> Nx.window_sum({1, 2})
+        |> Nx.remainder(2)
+        |> Nx.sum(axes: [1])
+
+      assert Nx.equal(number_of_points, Nx.tensor(points))
+    end
+  end
+end


### PR DESCRIPTION
Let's consider a 3-point crossover on genome with length 8. Similarly to the other crossovers we want to produce a swapping mask with 3 cuts as in `00110111`.

```elixir
# Step 1 - generate three unique random indices
4
2
5

# Step 2 - convert each point to a  1-point mask
00001111
00111111
00000111

# Step 3 - take a gen-wise sum
00112333

# Step 4 - take modulo 2 (every crossover point changes the parity)
00110111
```

This example shows mask generation for a single pair of parents, then we generalize this approach to generate multiple such masks at once.