### PR TITLE
Move APIs to the top level, add more docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,16 @@ end
 
 # Define the evolutionary model (algorithm)
 
-alias Meow.{Model, Pipeline, Runner}
-
 model =
-  Model.new(
+  Meow.objective(
     # Specify the evaluation function that we are trying to maximise
     &Problem.evaluate_rastrigin/1
   )
-  |> Model.add_pipeline(
+  |> Meow.add_pipeline(
     # Define how the population is initialized and what representation to use
     MeowNx.Ops.init_real_random_uniform(100, Problem.size(), -5.12, 5.12),
     # A single pipeline corresponds to a single population
-    Pipeline.new([
+    Meow.pipeline([
       # Define a number of evolutionary steps that the population goes through
       MeowNx.Ops.selection_tournament(1.0),
       MeowNx.Ops.crossover_uniform(0.5),
@@ -61,11 +59,12 @@ model =
     ])
   )
 
+
 # Execute the above model
 
-report = Runner.run(model)
+report = Meow.run(model)
 
-report |> Report.format_summary() |> IO.puts()
+report |> Meow.Report.format_summary() |> IO.puts()
 ```
 
 Then you simply run the script

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ model =
 
 report = Runner.run(model)
 
-report |> Runner.Report.format_summary() |> IO.puts()
+report |> Report.format_summary() |> IO.puts()
 ```
 
-Then you can simply run the script
+Then you simply run the script
 
 ```shell
 $ elixir example.exs
@@ -90,7 +90,7 @@ Genome: #Nx.Tensor<
 >
 ```
 
-You can find more examples in the [examples](https://github.com/jonatanklosko/meow/tree/main/examples) directory.
+Check out more examples in the [examples](https://github.com/jonatanklosko/meow/tree/main/examples) directory.
 
 ### Interactive exploration
 

--- a/examples/distributed.exs
+++ b/examples/distributed.exs
@@ -30,13 +30,11 @@ defmodule Problem do
   end
 end
 
-alias Meow.{Model, Pipeline}
-
 model =
-  Model.new(&Problem.evaluate_rastrigin/1)
-  |> Model.add_pipeline(
+  Meow.objective(&Problem.evaluate_rastrigin/1)
+  |> Meow.add_pipeline(
     MeowNx.Ops.init_real_random_uniform(100, Problem.size(), -5.12, 5.12),
-    Pipeline.new([
+    Meow.pipeline([
       MeowNx.Ops.selection_tournament(1.0),
       MeowNx.Ops.crossover_uniform(0.5),
       MeowNx.Ops.mutation_shift_gaussian(0.001),
@@ -58,6 +56,6 @@ model =
   )
 
 Meow.Distribution.init_from_cli_args!(fn nodes ->
-  report = Meow.Runner.run(model, nodes: nodes)
-  report |> Meow.Runner.Report.format_summary() |> IO.puts()
+  report = Meow.run(model, nodes: nodes)
+  report |> Meow.Report.format_summary() |> IO.puts()
 end)

--- a/examples/intro.exs
+++ b/examples/intro.exs
@@ -28,18 +28,16 @@ end
 
 # Define the evolutionary model (algorithm)
 
-alias Meow.{Model, Pipeline, Runner}
-
 model =
-  Model.new(
+  Meow.objective(
     # Specify the evaluation function that we are trying to maximise
     &Problem.evaluate_rastrigin/1
   )
-  |> Model.add_pipeline(
+  |> Meow.add_pipeline(
     # Define how the population is initialized and what representation to use
     MeowNx.Ops.init_real_random_uniform(100, Problem.size(), -5.12, 5.12),
     # A single pipeline corresponds to a single population
-    Pipeline.new([
+    Meow.pipeline([
       # Define a number of evolutionary steps that the population goes through
       MeowNx.Ops.selection_tournament(1.0),
       MeowNx.Ops.crossover_uniform(0.5),
@@ -51,6 +49,5 @@ model =
 
 # Execute the above model
 
-report = Runner.run(model)
-
-report |> Runner.Report.format_summary() |> IO.puts()
+report = Meow.run(model)
+report |> Meow.Report.format_summary() |> IO.puts()

--- a/examples/knapsack.exs
+++ b/examples/knapsack.exs
@@ -33,13 +33,11 @@ defmodule Problem do
   end
 end
 
-alias Meow.{Model, Pipeline}
-
 model =
-  Model.new(&Problem.evaluate_knapsack/1)
-  |> Model.add_pipeline(
+  Meow.objective(&Problem.evaluate_knapsack/1)
+  |> Meow.add_pipeline(
     MeowNx.Ops.init_binary_random_uniform(100, Problem.size()),
-    Pipeline.new([
+    Meow.pipeline([
       MeowNx.Ops.selection_tournament(1.0),
       MeowNx.Ops.crossover_multi_point(3),
       MeowNx.Ops.mutation_bit_flip(0.1),
@@ -48,6 +46,5 @@ model =
     ])
   )
 
-report = Meow.Runner.run(model)
-
-report |> Meow.Runner.Report.format_summary() |> IO.puts()
+report = Meow.run(model)
+report |> Meow.Report.format_summary() |> IO.puts()

--- a/examples/metrics.exs
+++ b/examples/metrics.exs
@@ -22,13 +22,11 @@ defmodule Problem do
   end
 end
 
-alias Meow.{Model, Pipeline}
-
 model =
-  Model.new(&Problem.evaluate_rastrigin/1)
-  |> Model.add_pipeline(
+  Meow.objective(&Problem.evaluate_rastrigin/1)
+  |> Meow.add_pipeline(
     MeowNx.Ops.init_real_random_uniform(100, Problem.size(), -5.12, 5.12),
-    Pipeline.new([
+    Meow.pipeline([
       MeowNx.Ops.selection_tournament(1.0),
       MeowNx.Ops.crossover_uniform(0.5),
       MeowNx.Ops.mutation_shift_gaussian(0.001),
@@ -45,7 +43,7 @@ model =
     ])
   )
 
-%{population_reports: [%{population: population}]} = Meow.Runner.run(model)
+%{population_reports: [%{population: population}]} = Meow.run(model)
 
 IO.puts("\nLogged metrics:")
 IO.inspect(population.log.metrics)

--- a/examples/one_max.exs
+++ b/examples/one_max.exs
@@ -19,13 +19,11 @@ defmodule Problem do
   end
 end
 
-alias Meow.{Model, Pipeline}
-
 model =
-  Model.new(&Problem.evaluate_one_max/1)
-  |> Model.add_pipeline(
+  Meow.objective(&Problem.evaluate_one_max/1)
+  |> Meow.add_pipeline(
     MeowNx.Ops.init_binary_random_uniform(100, Problem.size()),
-    Pipeline.new([
+    Meow.pipeline([
       MeowNx.Ops.selection_tournament(1.0),
       MeowNx.Ops.crossover_uniform(0.5),
       MeowNx.Ops.mutation_bit_flip(0.001),
@@ -34,6 +32,6 @@ model =
     ])
   )
 
-report = Meow.Runner.run(model)
+report = Meow.run(model)
 
-report |> Meow.Runner.Report.format_summary() |> IO.puts()
+report |> Meow.Report.format_summary() |> IO.puts()

--- a/examples/rastrigin.exs
+++ b/examples/rastrigin.exs
@@ -9,7 +9,6 @@ Mix.install([
 
 defmodule Rastrigin do
   import Nx.Defn
-  alias Meow.{Model, Pipeline, Population, Topology}
 
   def size, do: 100
 
@@ -25,10 +24,10 @@ defmodule Rastrigin do
   end
 
   def model_simple() do
-    Model.new(&evaluate/1)
-    |> Model.add_pipeline(
+    Meow.objective(&evaluate/1)
+    |> Meow.add_pipeline(
       MeowNx.Ops.init_real_random_uniform(100, size(), -5.12, 5.12),
-      Pipeline.new([
+      Meow.pipeline([
         MeowNx.Ops.selection_tournament(1.0),
         MeowNx.Ops.crossover_uniform(0.5),
         MeowNx.Ops.mutation_replace_uniform(0.001, -5.12, 5.12),
@@ -39,14 +38,14 @@ defmodule Rastrigin do
   end
 
   def model_simple_multi() do
-    Model.new(&evaluate/1)
-    |> Model.add_pipeline(
+    Meow.objective(&evaluate/1)
+    |> Meow.add_pipeline(
       MeowNx.Ops.init_real_random_uniform(100, size(), -5.12, 5.12),
-      Pipeline.new([
+      Meow.pipeline([
         MeowNx.Ops.selection_tournament(1.0),
         MeowNx.Ops.crossover_uniform(0.5),
         MeowNx.Ops.mutation_shift_gaussian(0.001),
-        Meow.Ops.emigrate(MeowNx.Ops.selection_tournament(5), &Topology.ring/2, interval: 10),
+        Meow.Ops.emigrate(MeowNx.Ops.selection_tournament(5), &Meow.Topology.ring/2, interval: 10),
         Meow.Ops.immigrate(&MeowNx.Ops.selection_natural(&1), interval: 10),
         MeowNx.Ops.log_best_individual(),
         Meow.Ops.max_generations(5_000)
@@ -56,17 +55,17 @@ defmodule Rastrigin do
   end
 
   def model_branching() do
-    Model.new(&evaluate/1)
-    |> Model.add_pipeline(
+    Meow.objective(&evaluate/1)
+    |> Meow.add_pipeline(
       MeowNx.Ops.init_real_random_uniform(100, size(), -5.12, 5.12),
-      Pipeline.new([
+      Meow.pipeline([
         # Here the pipeline branches out into two sub-pipelines,
         # which results are then concatenation into a single population.
         Meow.Ops.split_join([
-          Pipeline.new([
+          Meow.pipeline([
             MeowNx.Ops.selection_natural(0.2)
           ]),
-          Pipeline.new([
+          Meow.pipeline([
             MeowNx.Ops.selection_tournament(0.8),
             MeowNx.Ops.crossover_blend_alpha(0.5),
             MeowNx.Ops.mutation_shift_gaussian(0.001)
@@ -85,6 +84,5 @@ end
 # model = Rastrigin.model_simple_multi()
 model = Rastrigin.model_branching()
 
-report = Meow.Runner.run(model)
-
-report |> Meow.Runner.Report.format_summary() |> IO.puts()
+report = Meow.run(model)
+report |> Meow.Report.format_summary() |> IO.puts()

--- a/lib/meow.ex
+++ b/lib/meow.ex
@@ -13,14 +13,14 @@ defmodule Meow do
 
   A single pipeline describes the evolution of one population,
   and by defining multiple pipelines we effectively get a
-  multi-population algorithm. Also, if we there are multiple
+  multi-population algorithm. Also, if there are multiple
   populations, we generally want them to communicate, which
   can be achieved by including a migration step in the pipelines.
 
   ## Example
 
   We will start with an easy and predictable example. Let's
-  consider a simple multivariable function that takes the sum of
+  consider a simple multivariable function that takes a sum of
   all the arguments.
 
   $$
@@ -42,12 +42,12 @@ defmodule Meow do
   \end{bmatrix} \\\\
   $$
 
-  So now our objcetive is to **maximise** this function.
+  Our objective is to **maximise** this function.
 
   In evolutionary terms $x_0$ is an individual genome with each gene
   being either $0$ or $1$, whereas $f$ is the **fitness** function that
   tells us how good the given individual is. Consequently our objective
-  is to generate an individual with highest possible fitness.
+  is to generate an individual with the highest fitness possible.
 
   There's not much we can do with a single individual, so we get more
   of these and form a **population**:
@@ -98,7 +98,7 @@ defmodule Meow do
   Also, note that the function above calculates fitness for the whole population,
   so the returned value is a vector of fitness values.
 
-  At this point we already defined what problem we are trying to solve, the
+  At this point we have already defined what problem we are trying to solve, the
   only missing piece is an algorithm to solve it.
 
       model =
@@ -116,7 +116,7 @@ defmodule Meow do
 
   Let's break down what we just did. We start modeling our algorithm by
   specifying the objective function `f`. Then we specify how the population
-  should be iniaizlied, in this case we generate 100 individuals, each with
+  should be initialised, in this case we generate 100 individuals, each with
   `Problem.size()` genes. Finally, we list the operations that should be
   applied to the population on every iteration.
 
@@ -130,7 +130,7 @@ defmodule Meow do
 
   By its nature, those algorithms are random in nature and fall under
   the category of heuristics. Nonetheless for a number of problems heuristics
-  are best we have and Meow attempts at making experimentation easy and
+  are the best we have and Meow attempts to make experimentation easy and
   efficient.
 
   ## Learn more
@@ -162,7 +162,7 @@ defmodule Meow do
   Each pipeline defines how a single population evolves,
   so multiple pipelines imply multi-population model.
 
-  When the model is run, `initializer` is aplied to an empty
+  When the model is run, `initializer` is applied to an empty
   population, then the resulting population is repeatedly
   passed through the pipeline until termination.
 
@@ -192,7 +192,7 @@ defmodule Meow do
   ## Options
 
     * `:nodes` - a list of nodes available for running the
-      algorithm. Note that all of the nodes must already be
+      algorithm. Note that all of the nodes must be already
       connected and all relevant modules must be available
       for every node. Defaults to `[node()]`.
 

--- a/lib/meow.ex
+++ b/lib/meow.ex
@@ -1,7 +1,213 @@
 defmodule Meow do
-  @moduledoc """
+  @moduledoc ~S"""
   Meow is a framework for composing and running evolutionary
-  algorithms, with support for multi-population variants
-  and distributed computing.
+  algorithms, with support for multi-population variants and
+  distributed computing.
+
+  ## Concepts
+
+  In Meow an evolutionary algorithm is defined as a pipeline
+  of operations that the population goes through, until the
+  termination criteria is met. Each operation is a building
+  block that transforms the population in some way.
+
+  A single pipeline describes the evolution of one population,
+  and by defining multiple pipelines we effectively get a
+  multi-population algorithm. Also, if we there are multiple
+  populations, we generally want them to communicate, which
+  can be achieved by including a migration step in the pipelines.
+
+  ## Example
+
+  We will start with an easy and predictable example. Let's
+  consider a simple multivariable function that takes the sum of
+  all the arguments.
+
+  $$
+  f(x_0, ..., x_n) = x_0 + ... + x_n
+  $$
+
+  Or in vector notation:
+
+  $$
+  f(x) = \sum_{i} x_i
+  $$
+
+  Additionally, let's assume each argument can be either $0$ or $1$,
+  so a possible argument would look like this:
+
+  $$
+  x_0 = \begin{bmatrix}
+  0 & 1 & 1 & 0 & 1 & 0 \\\\
+  \end{bmatrix} \\\\
+  $$
+
+  So now our objcetive is to **maximise** this function.
+
+  In evolutionary terms $x_0$ is an individual genome with each gene
+  being either $0$ or $1$, whereas $f$ is the **fitness** function that
+  tells us how good the given individual is. Consequently our objective
+  is to generate an individual with highest possible fitness.
+
+  There's not much we can do with a single individual, so we get more
+  of these and form a **population**:
+
+  $$
+  X = \begin{bmatrix}
+  0 & 1 & 1 & 0 & 1 & 0 \\\\
+  1 & 1 & 0 & 0 & 0 & 1 \\\\
+  0 & 0 & 1 & 1 & 1 & 0 \\\\
+  1 & 0 & 1 & 0 & 1 & 1
+  \end{bmatrix}
+  $$
+
+  The basic idea behind an evolutionary algorithm is to let this population
+  evolve over time, until we generate a very fit individual. To do this,
+  we use various operations, such as:
+
+    * **selection** - picking individuals based on their properties
+
+    * **crossover** - taking a number of individuals (parents) and combining
+      them to produce new individuals (children)
+
+    * **mutation** - altering some genes in a random fashion
+
+  These are just a few basic groups, but in practice operations may do any
+  transformations, with the eventual goal of improving the population.
+
+  ### Coding it up
+
+  Let's see how we can use Meow to put all of these terms into code.
+  The first thing we need is to define the fitness function.
+
+      defmodule Problem do
+        import Nx.Defn
+
+        def size, do: 100
+
+        @defn_compiler EXLA
+        defn f(genomes) do
+          Nx.sum(genomes, axes: [1])
+        end
+      end
+
+  Since we are dealing with heavily numerical problems we use Elixir Nx
+  to work with numbers. Meow core doesn't assume that, but most of the
+  built-in operations use Nx underneath (see `MeowNx`).
+
+  Also, note that the function above calculates fitness for the whole population,
+  so the returned value is a vector of fitness values.
+
+  At this point we already defined what problem we are trying to solve, the
+  only missing piece is an algorithm to solve it.
+
+      model =
+        Meow.objective(&Problem.f/1)
+        |> Meow.add_pipeline(
+          MeowNx.Ops.init_binary_random_uniform(100, Problem.size()),
+          Meow.pipeline([
+            MeowNx.Ops.selection_tournament(1.0),
+            MeowNx.Ops.crossover_uniform(0.5),
+            MeowNx.Ops.mutation_bit_flip(0.001),
+            MeowNx.Ops.log_best_individual(),
+            Meow.Ops.max_generations(100)
+          ])
+        )
+
+  Let's break down what we just did. We start modeling our algorithm by
+  specifying the objective function `f`. Then we specify how the population
+  should be iniaizlied, in this case we generate 100 individuals, each with
+  `Problem.size()` genes. Finally, we list the operations that should be
+  applied to the population on every iteration.
+
+  Now we just need to run our algorithm:
+
+      report = Meow.run(model)
+      report |> Meow.Report.format_summary() |> IO.puts()
+
+  Hopefully this gives us a good solution to our problem, in this case an
+  individual with all genes set to 1.
+
+  By its nature, those algorithms are random in nature and fall under
+  the category of heuristics. Nonetheless for a number of problems heuristics
+  are best we have and Meow attempts at making experimentation easy and
+  efficient.
+
+  ## Learn more
+
+  The above example presents a simple single-population model, but there's
+  much more you can do with Meow. Check out the Guides section for interactive
+  notebooks that you can easily try out yourself. Additionally, there's a number
+  of examples in the GitHub repository, so feel free explore those too.
   """
+
+  @doc """
+  Entry point for building a new evolutionary model.
+
+  The given function becomes the optimisation objective
+  that the algorithm will try to maximise.
+  """
+  @spec objective(Meow.Model.evaluate()) :: Meow.Model.t()
+  defdelegate objective(evaluate), to: Meow.Model, as: :new
+
+  @doc """
+  Builds a new pipeline from a list of operations.
+  """
+  @spec pipeline(list(Meow.Op.t())) :: Meow.Pipeline.t()
+  defdelegate pipeline(ops), to: Meow.Pipeline, as: :new
+
+  @doc """
+  Adds an evolutionary pipeline to the model definition.
+
+  Each pipeline defines how a single population evolves,
+  so multiple pipelines imply multi-population model.
+
+  When the model is run, `initializer` is aplied to an empty
+  population, then the resulting population is repeatedly
+  passed through the pipeline until termination.
+
+  ## Options
+
+    * `:duplicate` - how many copies of the pipeline to add.
+      Multiple copies imply a multi-population algorithm. Defaults to 1.
+  """
+  @spec add_pipeline(Meow.Model.t(), Meow.Op.t(), Meow.Pipeline.t(), keyword()) :: Meow.Model.t()
+  defdelegate add_pipeline(model, initializer, pipeline, opts \\ []), to: Meow.Model
+
+  @doc """
+  Iteratively transforms populations according to the given
+  model until all populations are terminated.
+
+  ## Distribution
+
+  In case of a multi-population algorithm the populations
+  evolve in parallel, by default within the current runtime.
+
+  If multiple runtime nodes are available, the algorithm may
+  be run in a distributed setup by specifying the `:nodes`
+  option. In that case the populations are distributed among
+  said nodes, which can be further controlled with the
+  `:population_groups` option.
+
+  ## Options
+
+    * `:nodes` - a list of nodes available for running the
+      algorithm. Note that all of the nodes must already be
+      connected and all relevant modules must be available
+      for every node. Defaults to `[node()]`.
+
+    * `:population_groups` - a list of groups, where each
+      group is a list of population indices. Populations
+      from the same group will be run on the same node.
+      The number of groups should match the number of nodes
+      configured via `:nodes` and every population must be
+      in exactly one of the groups. By default populations
+      are split into even groups.
+
+    * `:global_opts` - options available to all operations.
+      This may be useful for some integrations, for example
+      to specify JIT compilation options when using `MeowNx`.
+  """
+  @spec run(Meow.Model.t(), keyword()) :: Meow.Report.t()
+  defdelegate run(model, opts \\ []), to: Meow.Runner
 end

--- a/lib/meow/model.ex
+++ b/lib/meow/model.ex
@@ -24,30 +24,14 @@ defmodule Meow.Model do
   """
   @type evaluate :: (Population.genomes() -> Population.fitness())
 
-  @doc """
-  Entrypoint for building a new model definition.
-  """
-  @spec new(evaluate()) :: t()
+  @doc false
+  # See `Meow.objective/1`
   def new(evaluate) do
     %__MODULE__{evaluate: evaluate}
   end
 
-  @doc """
-  Adds an evolutionary pipeline to the model definition.
-
-  Each pipeline defines how a single population evolves,
-  so multiple pipelines imply multi-population model.
-
-  When the model is run, `initializer` is aplied to an empty
-  population, then the resulting population is repeatedly
-  passed through the pipeline until termination.
-
-  ## Options
-
-    * `:duplicate` - how many copies of the pipeline to add.
-      Multiple copies imply a multi-population algorithm. Defaults to 1.
-  """
-  @spec add_pipeline(t(), Op.t(), Pipeline.t()) :: t()
+  @doc false
+  # See `Meow.add_pipeline/4`
   def add_pipeline(model, initializer, pipeline, opts \\ []) do
     validate_initializer!(initializer)
     validate_pipeline!(pipeline, initializer.out_representation)

--- a/lib/meow/pipeline.ex
+++ b/lib/meow/pipeline.ex
@@ -18,10 +18,8 @@ defmodule Meow.Pipeline do
           ops: list(Op.t())
         }
 
-  @doc """
-  Builds a new pipeline from a list of operations.
-  """
-  @spec new(list(Op.t())) :: t()
+  @doc false
+  # See `Meow.pipeline/1`
   def new(ops) do
     %__MODULE__{ops: ops}
   end

--- a/lib/meow/report.ex
+++ b/lib/meow/report.ex
@@ -1,4 +1,4 @@
-defmodule Meow.Runner.Report do
+defmodule Meow.Report do
   @moduledoc """
   Final results and information produced during a model run.
   """

--- a/lib/meow/runner.ex
+++ b/lib/meow/runner.ex
@@ -1,46 +1,12 @@
 defmodule Meow.Runner do
-  @moduledoc """
-  A module responsible for running an evolutionary algorithm,
-  as defined by `Meow.Model`.
-  """
+  @moduledoc false
 
-  alias Meow.{Pipeline, Population, Model, Op}
+  # A module responsible for running an evolutionary algorithm,
+  # as defined by `Meow.Model`.
 
-  @doc """
-  Iteratively transforms populations according to the given
-  model until all populations are terminated.
+  alias Meow.{Pipeline, Population, Op}
 
-  ## Distribution
-
-  In case of a multi-population algorithm the populations
-  evolve in parallel, by default within the current runtime.
-
-  If multiple runtime nodes are available, the algorithm may
-  be run in a distributed setup by specifying the `:nodes`
-  option. In that case the populations are distributed among
-  said nodes, which can be further controlled with the
-  `:population_groups` option.
-
-  ## Options
-
-    * `:nodes` - a list of nodes available for running the
-      algorithm. Note that all of the nodes must already be
-      connected and all relevant modules must be available
-      for every node. Defaults to `[node()]`.
-
-    * `:population_groups` - a list of groups, where each
-      group is a list of population indices. Populations
-      from the same group will be run on the same node.
-      The number of groups should match the number of nodes
-      configured via `:nodes` and every population must be
-      in exactly one of the groups. By default populations
-      are split into even groups.
-
-    * `:global_opts` - options available to all operations.
-      This may be useful for some integrations, for example
-      to specify JIT compilation options when using `MeowNx`.
-  """
-  @spec run(Model.t(), keyword()) :: Meow.Runner.Report.t()
+  # See `Meow.run/2`
   def run(model, opts \\ []) do
     nodes = opts[:nodes] || [node()]
     validate_nodes!(nodes)
@@ -60,7 +26,7 @@ defmodule Meow.Runner do
     {time, result_tuples} =
       :timer.tc(&run_model/4, [model, nodes, population_groups, global_opts])
 
-    %Meow.Runner.Report{
+    %Meow.Report{
       total_time_us: time,
       population_reports:
         for(

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Meow.MixProject do
 
   defp docs do
     [
-      main: "readme",
+      main: "Meow",
       source_url: "https://github.com/jonatanklosko/meow",
       # source_ref: "v#{@version}"
       source_ref: "main",
@@ -41,17 +41,15 @@ defmodule Meow.MixProject do
         {:"notebooks/rastrigin_intro.livemd", [title: "Introduction"]},
         {:"notebooks/metrics.livemd", [title: "Metrics and visualizations"]}
       ],
+      extra_section: "GUIDES",
       groups_for_modules: [
-        Model: [
-          Meow.Model,
-          Meow.Pipeline,
+        "Building blocks": [
           Meow.Topology,
           Meow.Ops,
           MeowNx.Ops
         ],
         Runtime: [
-          Meow.Runner,
-          Meow.Runner.Report,
+          Meow.Report,
           Meow.Distribution
         ],
         "Numerical definitions": [
@@ -62,6 +60,8 @@ defmodule Meow.MixProject do
           MeowNx.Metric
         ],
         "Lower level": [
+          Meow.Model,
+          Meow.Pipeline,
           Meow.Op,
           Meow.Op.Context,
           Meow.Population,

--- a/notebooks/metrics.livemd
+++ b/notebooks/metrics.livemd
@@ -18,10 +18,6 @@ Mix.install([
 ])
 ```
 
-```elixir
-alias Meow.{Model, Pipeline, Population, Topology, Runner}
-```
-
 ## Recording metrics
 
 In the [introduction notebook](./rastrigin_intro.livemd) we worked with
@@ -57,10 +53,10 @@ so you can easily plug in your own!
 
 ```elixir
 model =
-  Model.new(&Problem.evaluate_rastrigin/1)
-  |> Model.add_pipeline(
+  Meow.objective(&Problem.evaluate_rastrigin/1)
+  |> Meow.add_pipeline(
     MeowNx.Ops.init_real_random_uniform(100, Problem.size(), -5.12, 5.12),
-    Pipeline.new([
+    Meow.pipeline([
       MeowNx.Ops.selection_tournament(1.0),
       MeowNx.Ops.crossover_uniform(0.5),
       MeowNx.Ops.mutation_replace_uniform(0.001, -5.12, 5.12),
@@ -80,7 +76,7 @@ model =
   )
 
 # And run the model
-report = Runner.run(model)
+report = Meow.run(model)
 
 :ok
 ```
@@ -89,14 +85,14 @@ After running the model we get a bunch of information that we store in the
 `report` variable. We already know how to extract a brief summary out of it:
 
 ```elixir
-report |> Runner.Report.format_summary() |> IO.puts()
+report |> Meow.Report.format_summary() |> IO.puts()
 ```
 
 So this tells us what the best individual is, but we collected a bunch
 of metrics along the way, let's see them!
 
 ```elixir
-Runner.Report.plot_metrics(report)
+Meow.Report.plot_metrics(report)
 ```
 
 There we go, all metrics ready to analyze. The plots are interactive
@@ -106,23 +102,23 @@ This plots all the metrics in one shot, but we can also explicitly
 pick a metric to visualize.
 
 ```elixir
-Runner.Report.plot_metric(report, :fitness_max)
+Meow.Report.plot_metric(report, :fitness_max)
 ```
 
 Or alternatively
 
 ```elixir
-Runner.Report.plot_metric(report, :fitness_max, arrange: :grid)
+Meow.Report.plot_metric(report, :fitness_max, arrange: :grid)
 ```
 
 Finally, we can see how long each population took, both time-wise and generation-wise.
 
 ```elixir
-Runner.Report.plot_times(report)
+Meow.Report.plot_times(report)
 ```
 
 ```elixir
-Runner.Report.plot_generations(report)
+Meow.Report.plot_generations(report)
 ```
 
 This is not particularly useful for our simple, homogenous model, but can provide some
@@ -153,10 +149,10 @@ metrics_op =
   )
 
 model =
-  Model.new(&Problem.evaluate_rastrigin/1)
-  |> Model.add_pipeline(
+  Meow.objective(&Problem.evaluate_rastrigin/1)
+  |> Meow.add_pipeline(
     initializer_op,
-    Pipeline.new([
+    Meow.pipeline([
       MeowNx.Ops.selection_tournament(1.0),
       MeowNx.Ops.crossover_uniform(0.5),
       MeowNx.Ops.mutation_replace_uniform(0.001, -5.12, 5.12),
@@ -168,14 +164,14 @@ model =
     ]),
     duplicate: 2
   )
-  |> Model.add_pipeline(
+  |> Meow.add_pipeline(
     initializer_op,
-    Pipeline.new([
+    Meow.pipeline([
       Meow.Ops.split_join([
-        Pipeline.new([
+        Meow.pipeline([
           MeowNx.Ops.selection_natural(0.2)
         ]),
-        Pipeline.new([
+        Meow.pipeline([
           MeowNx.Ops.selection_tournament(0.8),
           MeowNx.Ops.crossover_blend_alpha(0.5),
           MeowNx.Ops.mutation_shift_gaussian(0.001)
@@ -192,8 +188,8 @@ model =
 
 # Execute the above model
 
-report = Runner.run(model)
-report |> Runner.Report.format_summary() |> IO.puts()
+report = Meow.run(model)
+report |> Meow.Report.format_summary() |> IO.puts()
 ```
 
 *Note: populations are ordered in the same manner as pipelines, so in this
@@ -201,7 +197,7 @@ case populations 0 and 1 evolve according to the first one, while populations
 2 and 3 according to the second one.*
 
 ```elixir
-Runner.Report.plot_metrics(report)
+Meow.Report.plot_metrics(report)
 ```
 
 The populations evolve independently, so we can see that both

--- a/notebooks/rastrigin_intro.livemd
+++ b/notebooks/rastrigin_intro.livemd
@@ -15,12 +15,6 @@ Mix.install([
 ])
 ```
 
-Let's also add some aliases to make the algorithm definitions less verbose.
-
-```elixir
-alias Meow.{Model, Pipeline, Population, Topology, Runner}
-```
-
 ## Objective
 
 The first step is defining the optimisation objective function.
@@ -87,15 +81,15 @@ random individuals, each with 100 floating-point genomes (meaning we optimise
 
 ```elixir
 model =
-  Model.new(
+  Meow.objective(
     # Specify the evaluation function that we are trying to maximise
     &Problem.evaluate_rastrigin/1
   )
-  |> Model.add_pipeline(
+  |> Meow.add_pipeline(
     # Initialize the population with 100 random individuals
     MeowNx.Ops.init_real_random_uniform(100, Problem.size(), -5.12, 5.12),
     # A single pipeline corresponds to a single population
-    Pipeline.new([
+    Meow.pipeline([
       # Define a number of evolutionary steps that the population goes through
       MeowNx.Ops.selection_tournament(1.0),
       MeowNx.Ops.crossover_uniform(0.5),
@@ -106,8 +100,8 @@ model =
   )
 
 # Execute the above model
-report = Runner.run(model)
-report |> Runner.Report.format_summary() |> IO.puts()
+report = Meow.run(model)
+report |> Meow.Report.format_summary() |> IO.puts()
 ```
 
 By looking at the best genome we can infer that the solution
@@ -132,17 +126,17 @@ Let's see this in practice, together with other crossover and muation types.
 
 ```elixir
 model =
-  Model.new(&Problem.evaluate_rastrigin/1)
-  |> Model.add_pipeline(
+  Meow.objective(&Problem.evaluate_rastrigin/1)
+  |> Meow.add_pipeline(
     MeowNx.Ops.init_real_random_uniform(100, Problem.size(), -5.12, 5.12),
-    Pipeline.new([
+    Meow.pipeline([
       # Here the pipeline branches out into two sub-pipelines,
       # which results are then joined into a single population.
       Meow.Ops.split_join([
-        Pipeline.new([
+        Meow.pipeline([
           MeowNx.Ops.selection_natural(0.2)
         ]),
-        Pipeline.new([
+        Meow.pipeline([
           MeowNx.Ops.selection_tournament(0.8),
           MeowNx.Ops.crossover_blend_alpha(0.5),
           MeowNx.Ops.mutation_shift_gaussian(0.001)
@@ -153,8 +147,8 @@ model =
     ])
   )
 
-report = Runner.run(model)
-report |> Runner.Report.format_summary() |> IO.puts()
+report = Meow.run(model)
+report |> Meow.Report.format_summary() |> IO.puts()
 ```
 
 This gives us a much more precise solution! The fitness is closer to 0
@@ -179,14 +173,14 @@ and use the ring topology.
 
 ```elixir
 model =
-  Model.new(&Problem.evaluate_rastrigin/1)
-  |> Model.add_pipeline(
+  Meow.objective(&Problem.evaluate_rastrigin/1)
+  |> Meow.add_pipeline(
     MeowNx.Ops.init_real_random_uniform(100, Problem.size(), -5.12, 5.12),
-    Pipeline.new([
+    Meow.pipeline([
       MeowNx.Ops.selection_tournament(1.0),
       MeowNx.Ops.crossover_uniform(0.5),
       MeowNx.Ops.mutation_shift_gaussian(0.001),
-      Meow.Ops.emigrate(MeowNx.Ops.selection_natural(5), &Topology.ring/2, interval: 10),
+      Meow.Ops.emigrate(MeowNx.Ops.selection_natural(5), &Meow.Topology.ring/2, interval: 10),
       Meow.Ops.immigrate(&MeowNx.Ops.selection_natural(&1), interval: 10),
       MeowNx.Ops.log_best_individual(),
       Meow.Ops.max_generations(5_000)
@@ -197,6 +191,6 @@ model =
     duplicate: 3
   )
 
-report = Runner.run(model)
-report |> Runner.Report.format_summary() |> IO.puts()
+report = Meow.run(model)
+report |> Meow.Report.format_summary() |> IO.puts()
 ```


### PR DESCRIPTION
I think our API is currently a bit too scattered, which manifests itself in that even for a simple example we use aliases to make module calls less verbose. In fact, some modules have just 1 or 2 relevant functions, which are used for pretty much every algorithm. The current API kinda makes sense on the implementation level, but we probably make the implementation details too prominent, forcing the end user to figure out the individual pieces. To address that I moved the primary functions to the `Meow` module, which helped to get rid of a bunch of alises.

I also extended the `Meow` module docs with a more detailed example, since that's what the user would expect.