### PR TITLE
Add explicit backend transfer to support keep_on_device

### DIFF
--- a/lib/meow.ex
+++ b/lib/meow.ex
@@ -203,10 +203,6 @@ defmodule Meow do
       configured via `:nodes` and every population must be
       in exactly one of the groups. By default populations
       are split into even groups.
-
-    * `:global_opts` - options available to all operations.
-      This may be useful for some integrations, for example
-      to specify JIT compilation options when using `MeowNx`.
   """
   @spec run(Meow.Model.t(), keyword()) :: Meow.Report.t()
   defdelegate run(model, opts \\ []), to: Meow.Runner

--- a/lib/meow/op.ex
+++ b/lib/meow/op.ex
@@ -58,28 +58,4 @@ defmodule Meow.Op do
       representation -> %{new_population | representation: representation}
     end
   end
-
-  # Helpers to use when building custom operations
-
-  @doc """
-  Updates population genomes with the given function.
-  """
-  @spec map_genomes(Population.t(), (Population.genomes() -> Population.genomes())) ::
-          Population.t()
-  def map_genomes(population, fun) do
-    update_in(population.genomes, fun)
-  end
-
-  @doc """
-  Updates both population genomes and fitness with the given function.
-  """
-  @spec map_genomes_and_fitness(
-          Population.t(),
-          (Population.genomes(), Population.fitness() ->
-             {Population.genomes(), Population.fitness()})
-        ) :: Population.t()
-  def map_genomes_and_fitness(population, fun) do
-    {genomes, fitness} = fun.(population.genomes, population.fitness)
-    %{population | genomes: genomes, fitness: fitness}
-  end
 end

--- a/lib/meow/op/context.ex
+++ b/lib/meow/op/context.ex
@@ -5,13 +5,12 @@ defmodule Meow.Op.Context do
   population.
   """
 
-  defstruct [:evaluate, :population_pids, :global_opts]
+  defstruct [:evaluate, :population_pids]
 
   alias Meow.Model
 
   @type t :: %__MODULE__{
           evaluate: Model.evaluate(),
-          population_pids: list(pid()),
-          global_opts: keyword()
+          population_pids: list(pid())
         }
 end

--- a/lib/meow/population.ex
+++ b/lib/meow/population.ex
@@ -157,4 +157,21 @@ defmodule Meow.Population do
               "the given populations have different representations, so they are not compatible"
     end
   end
+
+  @doc """
+  Updates population genomes with the given function.
+  """
+  @spec map_genomes(t(), (genomes() -> genomes())) :: t()
+  def map_genomes(population, fun) do
+    update_in(population.genomes, fun)
+  end
+
+  @doc """
+  Updates both population genomes and fitness with the given function.
+  """
+  @spec map_genomes_and_fitness(t(), (genomes(), fitness() -> {genomes(), fitness()})) :: t()
+  def map_genomes_and_fitness(population, fun) do
+    {genomes, fitness} = fun.(population.genomes, population.fitness)
+    %{population | genomes: genomes, fitness: fitness}
+  end
 end

--- a/lib/meow/runner.ex
+++ b/lib/meow/runner.ex
@@ -21,10 +21,7 @@ defmodule Meow.Runner do
 
     validate_population_groups!(population_groups, number_of_populations, number_of_nodes)
 
-    global_opts = opts[:global_opts] || []
-
-    {time, result_tuples} =
-      :timer.tc(&run_model/4, [model, nodes, population_groups, global_opts])
+    {time, result_tuples} = :timer.tc(&run_model/3, [model, nodes, population_groups])
 
     %Meow.Report{
       total_time_us: time,
@@ -75,7 +72,7 @@ defmodule Meow.Runner do
     Meow.Utils.split_evenly(indices, number_of_nodes)
   end
 
-  defp run_model(model, nodes, population_groups, global_opts) do
+  defp run_model(model, nodes, population_groups) do
     runner_pid = self()
 
     population_node_mapping =
@@ -95,8 +92,7 @@ defmodule Meow.Runner do
             {:initialize, pids} ->
               ctx = %Op.Context{
                 evaluate: model.evaluate,
-                population_pids: pids,
-                global_opts: global_opts
+                population_pids: pids
               }
 
               population = Op.apply(%Population{}, initializer, ctx)

--- a/lib/meow_nx.ex
+++ b/lib/meow_nx.ex
@@ -17,15 +17,95 @@ defmodule MeowNx do
   `MeowNx` provides a number of numerical definitions, as well
   as `Meow` operation builders on top of that. See `MeowNx.Ops`
   for the list of available operations.
-
-  ## Configuration
-
-  When running a model using `MeoxNx` operations the following
-  `global_opts` are available (passed to the runner):
-
-    * `:jit_opts` - options passed to `Nx.Defn.jit/3` when
-      compiling the underlying numerical definitions. This
-      defaults to `[compiler: EXLA]` if `exla` is available,
-      and to `[]` otherwise.
   """
+
+  # TODO: the JIT configuration may no longer be necessary once Nx makes
+  # the options globally configurable, see https://github.com/elixir-nx/nx/issues/506
+
+  @doc """
+  Configures the options passed to `Nx.Defn.jit/3` when compiling
+  numerical operations.
+  """
+  @spec configure_jit_opts(keyword()) :: :ok
+  def configure_jit_opts(opts) when is_list(opts) do
+    Application.put_env(:meow_nx, :jit_opts, opts)
+  end
+
+  defp jit_opts() do
+    cond do
+      opts = Application.get_env(:meow_nx, :jit_opts) -> opts
+      Code.ensure_loaded?(EXLA) -> [compiler: EXLA]
+      true -> []
+    end
+  end
+
+  @doc """
+  Compiles and invokes the given numerical function.
+
+  Use this function when extending `MeowNx` with custom operations.
+  For examples see the source code of `MeowNx.Ops`.
+
+  This is a wrapper around `Nx.Defn.jit/3` that does two additional
+  things:
+
+    * uses the JIT options configured with `configure_jit_opts/1`.
+      If no options have been configured and `exla` is available
+      defaults to `[compiler: EXLA]` and `[]` otherwise
+
+    * supports options and tensor lists in the argument list, which
+      ensures the usage is akin to `apply/2`
+
+  ## Examples
+
+      MeowNx.jit(&Mod.operation/2, [genomes, opts])
+  """
+  def jit(fun, args) do
+    # Split arguments into tensors that we actually pass to JIT
+    # and options that we access directly in the function wrapper
+    {infos, {tensor_map, opts_map}} =
+      args
+      |> Enum.with_index()
+      |> Enum.map_reduce({%{}, %{}}, fn {arg, i}, {tensor_map, opts_map} ->
+        cond do
+          is_list(arg) and Enum.all?(arg, &tensor_like?/1) ->
+            # Nx.Defn.jit/3 doesn't allow tensor list in arguments, so we convert it to tuple
+            {{:tensor_list, i}, {put_in(tensor_map[i], List.to_tuple(arg)), opts_map}}
+
+          Keyword.keyword?(arg) ->
+            {{:opts, i}, {tensor_map, put_in(opts_map[i], arg)}}
+
+          arg ->
+            {{:tensor, i}, {put_in(tensor_map[i], arg), opts_map}}
+        end
+      end)
+
+    fun_wrapper = fn tensor_map ->
+      args =
+        Enum.map(infos, fn
+          {:tensor_list, i} -> Tuple.to_list(tensor_map[i])
+          {:opts, i} -> opts_map[i]
+          {:tensor, i} -> tensor_map[i]
+        end)
+
+      apply(fun, args)
+    end
+
+    Nx.Defn.jit(fun_wrapper, [tensor_map], jit_opts())
+  end
+
+  defp tensor_like?(%Nx.Tensor{}), do: true
+  defp tensor_like?(n) when is_number(n), do: true
+  defp tensor_like?(_), do: false
+
+  @doc """
+  Returns the real representation descriptor.
+  """
+  @spec real_representation() :: Meow.Population.representation()
+  def real_representation(), do: {MeowNx.RepresentationSpec, :real}
+
+  @doc """
+  Returns the binary representation descriptor.
+  """
+  @spec binary_representation() :: Meow.Population.representation()
+  def binary_representation(), do: {MeowNx.RepresentationSpec, :binary}
 end

--- a/lib/meow_nx/ops.ex
+++ b/lib/meow_nx/ops.ex
@@ -7,7 +7,7 @@ defmodule MeowNx.Ops do
   in their respective modules.
   """
 
-  alias Meow.Op
+  alias Meow.{Op, Population}
   alias MeowNx.{Crossover, Init, Metric, Mutation, Selection}
 
   @representations [MeowNx.real_representation(), MeowNx.binary_representation()]
@@ -29,7 +29,7 @@ defmodule MeowNx.Ops do
       in_representations: :any,
       out_representation: MeowNx.real_representation(),
       impl: fn population, _ctx ->
-        Op.map_genomes(population, fn _genomes ->
+        Population.map_genomes(population, fn _genomes ->
           MeowNx.jit(&Init.real_random_uniform/1, [opts])
         end)
       end
@@ -53,7 +53,7 @@ defmodule MeowNx.Ops do
       in_representations: :any,
       out_representation: MeowNx.binary_representation(),
       impl: fn population, _ctx ->
-        Op.map_genomes(population, fn _genomes ->
+        Population.map_genomes(population, fn _genomes ->
           MeowNx.jit(&Init.binary_random_uniform/1, [opts])
         end)
       end
@@ -76,7 +76,7 @@ defmodule MeowNx.Ops do
       invalidates_fitness: false,
       in_representations: @representations,
       impl: fn population, _ctx ->
-        Op.map_genomes_and_fitness(population, fn genomes, fitness ->
+        Population.map_genomes_and_fitness(population, fn genomes, fitness ->
           MeowNx.jit(&Selection.tournament/3, [genomes, fitness, opts])
         end)
       end
@@ -99,7 +99,7 @@ defmodule MeowNx.Ops do
       invalidates_fitness: false,
       in_representations: @representations,
       impl: fn population, _ctx ->
-        Op.map_genomes_and_fitness(population, fn genomes, fitness ->
+        Population.map_genomes_and_fitness(population, fn genomes, fitness ->
           MeowNx.jit(&Selection.natural/3, [genomes, fitness, opts])
         end)
       end
@@ -122,7 +122,7 @@ defmodule MeowNx.Ops do
       invalidates_fitness: false,
       in_representations: @representations,
       impl: fn population, _ctx ->
-        Op.map_genomes_and_fitness(population, fn genomes, fitness ->
+        Population.map_genomes_and_fitness(population, fn genomes, fitness ->
           MeowNx.jit(&Selection.roulette/3, [genomes, fitness, opts])
         end)
       end
@@ -145,7 +145,7 @@ defmodule MeowNx.Ops do
       invalidates_fitness: false,
       in_representations: @representations,
       impl: fn population, _ctx ->
-        Op.map_genomes_and_fitness(population, fn genomes, fitness ->
+        Population.map_genomes_and_fitness(population, fn genomes, fitness ->
           MeowNx.jit(&Selection.stochastic_universal_sampling/3, [genomes, fitness, opts])
         end)
       end
@@ -168,7 +168,7 @@ defmodule MeowNx.Ops do
       invalidates_fitness: true,
       in_representations: @representations,
       impl: fn population, _ctx ->
-        Op.map_genomes(population, fn genomes ->
+        Population.map_genomes(population, fn genomes ->
           MeowNx.jit(&Crossover.uniform/2, [genomes, opts])
         end)
       end
@@ -189,7 +189,7 @@ defmodule MeowNx.Ops do
       invalidates_fitness: true,
       in_representations: @representations,
       impl: fn population, _ctx ->
-        Op.map_genomes(population, fn genomes ->
+        Population.map_genomes(population, fn genomes ->
           MeowNx.jit(&Crossover.single_point/1, [genomes])
         end)
       end
@@ -212,7 +212,7 @@ defmodule MeowNx.Ops do
       invalidates_fitness: true,
       in_representations: @representations,
       impl: fn population, _ctx ->
-        Op.map_genomes(population, fn genomes ->
+        Population.map_genomes(population, fn genomes ->
           MeowNx.jit(&Crossover.multi_point/2, [genomes, opts])
         end)
       end
@@ -235,7 +235,7 @@ defmodule MeowNx.Ops do
       invalidates_fitness: true,
       in_representations: [MeowNx.real_representation()],
       impl: fn population, _ctx ->
-        Op.map_genomes(population, fn genomes ->
+        Population.map_genomes(population, fn genomes ->
           MeowNx.jit(&Crossover.blend_alpha/2, [genomes, opts])
         end)
       end
@@ -258,7 +258,7 @@ defmodule MeowNx.Ops do
       invalidates_fitness: true,
       in_representations: [MeowNx.real_representation()],
       impl: fn population, _ctx ->
-        Op.map_genomes(population, fn genomes ->
+        Population.map_genomes(population, fn genomes ->
           MeowNx.jit(&Crossover.simulated_binary/2, [genomes, opts])
         end)
       end
@@ -281,7 +281,7 @@ defmodule MeowNx.Ops do
       invalidates_fitness: true,
       in_representations: [MeowNx.real_representation()],
       impl: fn population, _ctx ->
-        Op.map_genomes(population, fn genomes ->
+        Population.map_genomes(population, fn genomes ->
           MeowNx.jit(&Mutation.replace_uniform/2, [genomes, opts])
         end)
       end
@@ -304,7 +304,7 @@ defmodule MeowNx.Ops do
       invalidates_fitness: true,
       in_representations: [MeowNx.binary_representation()],
       impl: fn population, _ctx ->
-        Op.map_genomes(population, fn genomes ->
+        Population.map_genomes(population, fn genomes ->
           MeowNx.jit(&Mutation.bit_flip/2, [genomes, opts])
         end)
       end
@@ -327,7 +327,7 @@ defmodule MeowNx.Ops do
       invalidates_fitness: true,
       in_representations: [MeowNx.real_representation()],
       impl: fn population, _ctx ->
-        Op.map_genomes(population, fn genomes ->
+        Population.map_genomes(population, fn genomes ->
           MeowNx.jit(&Mutation.shift_gaussian/2, [genomes, opts])
         end)
       end

--- a/lib/meow_nx/ops.ex
+++ b/lib/meow_nx/ops.ex
@@ -9,11 +9,8 @@ defmodule MeowNx.Ops do
 
   alias Meow.Op
   alias MeowNx.{Crossover, Init, Metric, Mutation, Selection}
-  alias MeowNx.Utils
 
-  @real_representation {MeowNx.RepresentationSpec, :real}
-  @binary_representation {MeowNx.RepresentationSpec, :binary}
-  @representations [@real_representation, @binary_representation]
+  @representations [MeowNx.real_representation(), MeowNx.binary_representation()]
 
   @doc """
   Builds a random initializer for the real representation.
@@ -30,10 +27,10 @@ defmodule MeowNx.Ops do
       requires_fitness: false,
       invalidates_fitness: true,
       in_representations: :any,
-      out_representation: @real_representation,
-      impl: fn population, ctx ->
+      out_representation: MeowNx.real_representation(),
+      impl: fn population, _ctx ->
         Op.map_genomes(population, fn _genomes ->
-          Nx.Defn.jit(fn -> Init.real_random_uniform(opts) end, [], Utils.jit_opts(ctx))
+          MeowNx.jit(&Init.real_random_uniform/1, [opts])
         end)
       end
     }
@@ -54,10 +51,10 @@ defmodule MeowNx.Ops do
       requires_fitness: false,
       invalidates_fitness: true,
       in_representations: :any,
-      out_representation: @binary_representation,
-      impl: fn population, ctx ->
+      out_representation: MeowNx.binary_representation(),
+      impl: fn population, _ctx ->
         Op.map_genomes(population, fn _genomes ->
-          Nx.Defn.jit(fn -> Init.binary_random_uniform(opts) end, [], Utils.jit_opts(ctx))
+          MeowNx.jit(&Init.binary_random_uniform/1, [opts])
         end)
       end
     }
@@ -78,13 +75,9 @@ defmodule MeowNx.Ops do
       requires_fitness: true,
       invalidates_fitness: false,
       in_representations: @representations,
-      impl: fn population, ctx ->
+      impl: fn population, _ctx ->
         Op.map_genomes_and_fitness(population, fn genomes, fitness ->
-          Nx.Defn.jit(
-            &Selection.tournament(&1, &2, opts),
-            [genomes, fitness],
-            Utils.jit_opts(ctx)
-          )
+          MeowNx.jit(&Selection.tournament/3, [genomes, fitness, opts])
         end)
       end
     }
@@ -105,9 +98,9 @@ defmodule MeowNx.Ops do
       requires_fitness: true,
       invalidates_fitness: false,
       in_representations: @representations,
-      impl: fn population, ctx ->
+      impl: fn population, _ctx ->
         Op.map_genomes_and_fitness(population, fn genomes, fitness ->
-          Nx.Defn.jit(&Selection.natural(&1, &2, opts), [genomes, fitness], Utils.jit_opts(ctx))
+          MeowNx.jit(&Selection.natural/3, [genomes, fitness, opts])
         end)
       end
     }
@@ -128,9 +121,9 @@ defmodule MeowNx.Ops do
       requires_fitness: true,
       invalidates_fitness: false,
       in_representations: @representations,
-      impl: fn population, ctx ->
+      impl: fn population, _ctx ->
         Op.map_genomes_and_fitness(population, fn genomes, fitness ->
-          Nx.Defn.jit(&Selection.roulette(&1, &2, opts), [genomes, fitness], Utils.jit_opts(ctx))
+          MeowNx.jit(&Selection.roulette/3, [genomes, fitness, opts])
         end)
       end
     }
@@ -151,13 +144,9 @@ defmodule MeowNx.Ops do
       requires_fitness: true,
       invalidates_fitness: false,
       in_representations: @representations,
-      impl: fn population, ctx ->
+      impl: fn population, _ctx ->
         Op.map_genomes_and_fitness(population, fn genomes, fitness ->
-          Nx.Defn.jit(
-            &Selection.stochastic_universal_sampling(&1, &2, opts),
-            [genomes, fitness],
-            Utils.jit_opts(ctx)
-          )
+          MeowNx.jit(&Selection.stochastic_universal_sampling/3, [genomes, fitness, opts])
         end)
       end
     }
@@ -178,9 +167,9 @@ defmodule MeowNx.Ops do
       requires_fitness: false,
       invalidates_fitness: true,
       in_representations: @representations,
-      impl: fn population, ctx ->
+      impl: fn population, _ctx ->
         Op.map_genomes(population, fn genomes ->
-          Nx.Defn.jit(&Crossover.uniform(&1, opts), [genomes], Utils.jit_opts(ctx))
+          MeowNx.jit(&Crossover.uniform/2, [genomes, opts])
         end)
       end
     }
@@ -199,9 +188,9 @@ defmodule MeowNx.Ops do
       requires_fitness: false,
       invalidates_fitness: true,
       in_representations: @representations,
-      impl: fn population, ctx ->
+      impl: fn population, _ctx ->
         Op.map_genomes(population, fn genomes ->
-          Nx.Defn.jit(&Crossover.single_point(&1), [genomes], Utils.jit_opts(ctx))
+          MeowNx.jit(&Crossover.single_point/1, [genomes])
         end)
       end
     }
@@ -222,9 +211,9 @@ defmodule MeowNx.Ops do
       requires_fitness: false,
       invalidates_fitness: true,
       in_representations: @representations,
-      impl: fn population, ctx ->
+      impl: fn population, _ctx ->
         Op.map_genomes(population, fn genomes ->
-          Nx.Defn.jit(&Crossover.multi_point(&1, opts), [genomes], Utils.jit_opts(ctx))
+          MeowNx.jit(&Crossover.multi_point/2, [genomes, opts])
         end)
       end
     }
@@ -244,10 +233,10 @@ defmodule MeowNx.Ops do
       name: "[Nx] Crossover: blend-alpha",
       requires_fitness: false,
       invalidates_fitness: true,
-      in_representations: [@real_representation],
-      impl: fn population, ctx ->
+      in_representations: [MeowNx.real_representation()],
+      impl: fn population, _ctx ->
         Op.map_genomes(population, fn genomes ->
-          Nx.Defn.jit(&Crossover.blend_alpha(&1, opts), [genomes], Utils.jit_opts(ctx))
+          MeowNx.jit(&Crossover.blend_alpha/2, [genomes, opts])
         end)
       end
     }
@@ -267,10 +256,10 @@ defmodule MeowNx.Ops do
       name: "[Nx] Crossove: simulated binary",
       requires_fitness: false,
       invalidates_fitness: true,
-      in_representations: [@real_representation],
-      impl: fn population, ctx ->
+      in_representations: [MeowNx.real_representation()],
+      impl: fn population, _ctx ->
         Op.map_genomes(population, fn genomes ->
-          Nx.Defn.jit(&Crossover.simulated_binary(&1, opts), [genomes], Utils.jit_opts(ctx))
+          MeowNx.jit(&Crossover.simulated_binary/2, [genomes, opts])
         end)
       end
     }
@@ -290,10 +279,10 @@ defmodule MeowNx.Ops do
       name: "[Nx] Mutation: replace uniform",
       requires_fitness: false,
       invalidates_fitness: true,
-      in_representations: [@real_representation],
-      impl: fn population, ctx ->
+      in_representations: [MeowNx.real_representation()],
+      impl: fn population, _ctx ->
         Op.map_genomes(population, fn genomes ->
-          Nx.Defn.jit(&Mutation.replace_uniform(&1, opts), [genomes], Utils.jit_opts(ctx))
+          MeowNx.jit(&Mutation.replace_uniform/2, [genomes, opts])
         end)
       end
     }
@@ -313,10 +302,10 @@ defmodule MeowNx.Ops do
       name: "[Nx] Mutation: bit flip",
       requires_fitness: false,
       invalidates_fitness: true,
-      in_representations: [@binary_representation],
-      impl: fn population, ctx ->
+      in_representations: [MeowNx.binary_representation()],
+      impl: fn population, _ctx ->
         Op.map_genomes(population, fn genomes ->
-          Nx.Defn.jit(&Mutation.bit_flip(&1, opts), [genomes], Utils.jit_opts(ctx))
+          MeowNx.jit(&Mutation.bit_flip/2, [genomes, opts])
         end)
       end
     }
@@ -336,10 +325,10 @@ defmodule MeowNx.Ops do
       name: "[Nx] Mutation: shift Gaussian",
       requires_fitness: false,
       invalidates_fitness: true,
-      in_representations: [@real_representation],
-      impl: fn population, ctx ->
+      in_representations: [MeowNx.real_representation()],
+      impl: fn population, _ctx ->
         Op.map_genomes(population, fn genomes ->
-          Nx.Defn.jit(&Mutation.shift_gaussian(&1, opts), [genomes], Utils.jit_opts(ctx))
+          MeowNx.jit(&Mutation.shift_gaussian/2, [genomes, opts])
         end)
       end
     }
@@ -356,13 +345,10 @@ defmodule MeowNx.Ops do
       requires_fitness: true,
       invalidates_fitness: false,
       in_representations: @representations,
-      impl: fn population, ctx ->
+      impl: fn population, _ctx ->
         {best_genome, best_fitness} =
-          Nx.Defn.jit(
-            &Metric.best_individual/2,
-            [population.genomes, population.fitness],
-            Utils.jit_opts(ctx)
-          )
+          MeowNx.jit(&Metric.best_individual/2, [population.genomes, population.fitness])
+          |> Nx.backend_transfer()
 
         best_individual = %{
           genome: best_genome,
@@ -418,9 +404,12 @@ defmodule MeowNx.Ops do
       requires_fitness: true,
       invalidates_fitness: false,
       in_representations: @representations,
-      impl: fn population, ctx ->
+      impl: fn population, _ctx ->
         if rem(population.generation, interval) == 0 do
-          result = Nx.Defn.jit(fun, [population.genomes, population.fitness], Utils.jit_opts(ctx))
+          result =
+            fun
+            |> MeowNx.jit([population.genomes, population.fitness])
+            |> Nx.backend_transfer()
 
           entries =
             result

--- a/lib/meow_nx/representation_spec.ex
+++ b/lib/meow_nx/representation_spec.ex
@@ -12,11 +12,11 @@ defmodule MeowNx.RepresentationSpec do
 
   @impl true
   def concatenate_genomes(genomes_list) do
-    Nx.concatenate(genomes_list)
+    MeowNx.jit(&Nx.concatenate/1, [genomes_list])
   end
 
   @impl true
   def concatenate_fitness(fitness_list) do
-    Nx.concatenate(fitness_list)
+    MeowNx.jit(&Nx.concatenate/1, [fitness_list])
   end
 end

--- a/lib/meow_nx/utils.ex
+++ b/lib/meow_nx/utils.ex
@@ -278,23 +278,4 @@ defmodule MeowNx.Utils do
       raise ArgumentError, "expected size to not exceed the base size, but #{n} > #{base_n}"
     end
   end
-
-  # Other
-
-  @doc """
-  Returns `Nx.Defn.jit/3` options based on the global
-  configuration in context.
-  """
-  @spec jit_opts(Meow.Op.Context.t()) :: keyword()
-  def jit_opts(ctx) do
-    if opts = ctx.global_opts[:jit_opts] do
-      opts
-    else
-      if Code.ensure_loaded?(EXLA) do
-        [compiler: EXLA]
-      else
-        []
-      end
-    end
-  end
 end


### PR DESCRIPTION
I added calls to `Nx.backend_transfer/1` in the operations that collect metrics, so that it doesn't break when running with `keep_on_device: true`.

Also, I realised that in `MeowNx.RepresentationSpec` we call `Nx.concatenate/1` directly and it doesn't use the JIT options we use everywhere else, so I fixed that.

Finally, some of the calls to `Nx.Defn.jit/3` weren't particularly intuitive (especially tricky for `Nx.concatenate/1` mentioned above) and we always needed to remember about passing proper options. The primary concern is that if someone wants to add custom operations in a similar manner, this makes things more confusing than it should. Consequently, I added `MeowNx.jit/2` that always uses the configured options and handles some argument quirks, so that it works pretty much as `apply/2`.