### PR TITLE
Introduce operations for permutation problems

### DIFF
--- a/examples/knapsack.exs
+++ b/examples/knapsack.exs
@@ -1,12 +1,3 @@
-Mix.install([
-  {:meow, path: Path.expand("..", __DIR__)},
-  # or in a standalone script: {:meow, "~> 0.1.0-dev", github: "jonatanklosko/meow"},
-  {:nx, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "nx", override: true},
-  {:exla, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "exla"}
-])
-
-Nx.Defn.global_default_options(compiler: EXLA)
-
 # In "0-1 knapsnack problem" the objective is to pick a subset
 # of objects, such that the total weight is within limit and the
 # profit is maximised.
@@ -16,6 +7,15 @@ Nx.Defn.global_default_options(compiler: EXLA)
 
 # We use the binary representation, where n-th gene indicates whether
 # n-th object is in the subset.
+
+Mix.install([
+  {:meow, path: Path.expand("..", __DIR__)},
+  # or in a standalone script: {:meow, "~> 0.1.0-dev", github: "jonatanklosko/meow"},
+  {:nx, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "nx", override: true},
+  {:exla, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "exla"}
+])
+
+Nx.Defn.global_default_options(compiler: EXLA)
 
 defmodule Problem do
   import Nx.Defn

--- a/examples/one_max.exs
+++ b/examples/one_max.exs
@@ -1,3 +1,6 @@
+# In "one max" problem the objective is simply to maximise the number
+# of ones in a binary string.
+
 Mix.install([
   {:meow, path: Path.expand("..", __DIR__)},
   # or in a standalone script: {:meow, "~> 0.1.0-dev", github: "jonatanklosko/meow"},
@@ -6,9 +9,6 @@ Mix.install([
 ])
 
 Nx.Defn.global_default_options(compiler: EXLA)
-
-# In "one max" problem the objective is simply to maximise
-# the number of ones in a binary string.
 
 defmodule Problem do
   import Nx.Defn

--- a/examples/tsp.exs
+++ b/examples/tsp.exs
@@ -1,0 +1,88 @@
+# Traveling Salesman Problem (TSP)
+#
+# For problem description and example data sets see
+# https://people.sc.fsu.edu/~jburkardt/datasets/tsp/tsp.html
+#
+# Here we consider an example with 26 cities and the optimal total
+# distance of 937.
+
+Mix.install([
+  {:meow, path: Path.expand("..", __DIR__)},
+  # or in a standalone script: {:meow, "~> 0.1.0-dev", github: "jonatanklosko/meow"},
+  {:nx, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "nx", override: true},
+  {:exla, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "exla"},
+  {:req, "~> 0.2.1"}
+])
+
+Nx.Defn.global_default_options(compiler: EXLA)
+
+defmodule Problem do
+  import Nx.Defn
+
+  def load_distances(url) do
+    %{body: text} = Req.get!(url)
+
+    flat_distances =
+      text
+      |> String.split()
+      |> Enum.map(&String.to_integer/1)
+
+    size = flat_distances |> length() |> :math.sqrt() |> floor()
+
+    distances =
+      flat_distances
+      |> Nx.tensor()
+      |> Nx.reshape({size, size})
+
+    {size, distances}
+  end
+
+  defn evaluate(permutations, distance) do
+    {_n, length} = Nx.shape(permutations)
+
+    shifted =
+      Nx.concatenate(
+        [
+          Nx.slice_along_axis(permutations, 1, length - 1, axis: 1),
+          Nx.slice_along_axis(permutations, 0, 1, axis: 1)
+        ],
+        axis: 1
+      )
+
+    edges = Nx.stack([permutations, shifted], axis: -1)
+
+    total = distance |> Nx.gather(edges) |> Nx.sum(axes: [1])
+    -total
+  end
+end
+
+{tsp_size, distances} =
+  Problem.load_distances("https://people.sc.fsu.edu/~jburkardt/datasets/tsp/fri26_d.txt")
+
+algorithm =
+  Meow.objective(&Problem.evaluate(&1, distances))
+  |> Meow.add_pipeline(
+    MeowNx.Ops.Permutation.init_permutation_random(300, tsp_size),
+    Meow.pipeline([
+      Meow.Ops.split_join([
+        Meow.pipeline([
+          MeowNx.Ops.selection_natural(0.2)
+        ]),
+        Meow.pipeline([
+          MeowNx.Ops.selection_tournament(0.8),
+          MeowNx.Ops.Permutation.crossover_order(),
+          MeowNx.Ops.Permutation.mutation_inversion(0.5)
+        ])
+      ]),
+      Meow.Ops.emigrate(MeowNx.Ops.selection_natural(5), &Meow.Topology.ring/2, interval: 10),
+      Meow.Ops.immigrate(&MeowNx.Ops.selection_natural(&1), interval: 10),
+      MeowNx.Ops.log_best_individual(),
+      MeowNx.Ops.log_metrics(%{fitness_max: &MeowNx.Metric.fitness_max/2}, interval: 10),
+      Meow.Ops.max_generations(150)
+    ]),
+    duplicate: 4
+  )
+
+report = Meow.run(algorithm)
+
+report |> Meow.Report.format_summary() |> IO.puts()

--- a/lib/meow_nx.ex
+++ b/lib/meow_nx.ex
@@ -55,4 +55,10 @@ defmodule MeowNx do
   """
   @spec binary_representation() :: Meow.Population.representation()
   def binary_representation(), do: {MeowNx.RepresentationSpec, :binary}
+
+  @doc """
+  Returns the permutation representation descriptor.
+  """
+  @spec permutation_representation() :: Meow.Population.representation()
+  def permutation_representation(), do: {MeowNx.RepresentationSpec, :permutation}
 end

--- a/lib/meow_nx/ops.ex
+++ b/lib/meow_nx/ops.ex
@@ -12,7 +12,11 @@ defmodule MeowNx.Ops do
   alias Meow.{Op, Population}
   alias MeowNx.{Crossover, Init, Metric, Mutation, Selection}
 
-  @representations [MeowNx.real_representation(), MeowNx.binary_representation()]
+  @representations [
+    MeowNx.real_representation(),
+    MeowNx.binary_representation(),
+    MeowNx.permutation_representation()
+  ]
 
   @doc """
   Builds a random initializer for the real representation.
@@ -25,7 +29,7 @@ defmodule MeowNx.Ops do
     opts = [n: n, length: length, min: min, max: max]
 
     %Op{
-      name: "[Nx] Initialization: random uniform",
+      name: "[Nx] Initialization: real random uniform",
       requires_fitness: false,
       invalidates_fitness: true,
       in_representations: :any,
@@ -49,7 +53,7 @@ defmodule MeowNx.Ops do
     opts = [n: n, length: length]
 
     %Op{
-      name: "[Nx] Initialization: random uniform",
+      name: "[Nx] Initialization: binary random uniform",
       requires_fitness: false,
       invalidates_fitness: true,
       in_representations: :any,

--- a/lib/meow_nx/ops/permutation.ex
+++ b/lib/meow_nx/ops/permutation.ex
@@ -1,0 +1,162 @@
+defmodule MeowNx.Ops.Permutation do
+  @moduledoc """
+  Permutation operations backed by numerical definitions.
+  """
+
+  alias Meow.{Op, Population}
+  alias MeowNx.Permutation
+
+  @doc """
+  Builds a random initializer for the permutation representation.
+
+  See `MeowNx.Init.permutation_random/1` for more details.
+  """
+  @doc type: :init
+  @spec init_permutation_random(non_neg_integer(), non_neg_integer()) :: Op.t()
+  def init_permutation_random(n, length) do
+    opts = [n: n, length: length]
+
+    %Op{
+      name: "[Nx] Initialization: permutation random",
+      requires_fitness: false,
+      invalidates_fitness: true,
+      in_representations: :any,
+      out_representation: MeowNx.permutation_representation(),
+      impl: fn population, _ctx ->
+        Meow.Population.map_genomes(population, fn _genomes ->
+          Permutation.init_random(opts)
+        end)
+      end
+    }
+  end
+
+  @doc """
+  Builds a single point crossover operation adopted for permutations.
+
+  See `MeowNx.Permutation.crossover_single_point/1` for more details.
+  """
+  @doc type: :crossover
+  @spec crossover_single_point() :: Op.t()
+  def crossover_single_point() do
+    %Op{
+      name: "[Nx] Crossover: single point",
+      requires_fitness: false,
+      invalidates_fitness: true,
+      in_representations: [MeowNx.permutation_representation()],
+      impl: fn population, _ctx ->
+        Population.map_genomes(population, fn genomes ->
+          Permutation.crossover_single_point(genomes)
+        end)
+      end
+    }
+  end
+
+  @doc """
+  Builds an order crossover operation.
+
+  See `MeowNx.Permutation.crossover_order/1` for more details.
+  """
+  @doc type: :crossover
+  @spec crossover_order() :: Op.t()
+  def crossover_order() do
+    %Op{
+      name: "[Nx] Crossover: order",
+      requires_fitness: false,
+      invalidates_fitness: true,
+      in_representations: [MeowNx.permutation_representation()],
+      impl: fn population, _ctx ->
+        Population.map_genomes(population, fn genomes ->
+          Permutation.crossover_order(genomes)
+        end)
+      end
+    }
+  end
+
+  @doc """
+  Builds an position based crossover operation.
+
+  See `MeowNx.Permutation.crossover_position_based/1` for more details.
+  """
+  @doc type: :crossover
+  @spec crossover_position_based() :: Op.t()
+  def crossover_position_based() do
+    %Op{
+      name: "[Nx] Crossover: position based",
+      requires_fitness: false,
+      invalidates_fitness: true,
+      in_representations: [MeowNx.permutation_representation()],
+      impl: fn population, _ctx ->
+        Population.map_genomes(population, fn genomes ->
+          Permutation.crossover_position_based(genomes)
+        end)
+      end
+    }
+  end
+
+  @doc """
+  Builds a linear order crossover operation.
+
+  See `MeowNx.Permutation.crossover_linear_order/1` for more details.
+  """
+  @doc type: :crossover
+  @spec crossover_linear_order() :: Op.t()
+  def crossover_linear_order() do
+    %Op{
+      name: "[Nx] Crossover: linear order",
+      requires_fitness: false,
+      invalidates_fitness: true,
+      in_representations: [MeowNx.permutation_representation()],
+      impl: fn population, _ctx ->
+        Population.map_genomes(population, fn genomes ->
+          Permutation.crossover_linear_order(genomes)
+        end)
+      end
+    }
+  end
+
+  @doc """
+  Builds an inversion mutation operation.
+
+  See `MeowNx.Permutation.mutation_inversion/2` for more details.
+  """
+  @doc type: :mutation
+  @spec mutation_inversion(float()) :: Op.t()
+  def mutation_inversion(probability) do
+    opts = [probability: probability]
+
+    %Op{
+      name: "[Nx] Mutation: inversion",
+      requires_fitness: false,
+      invalidates_fitness: true,
+      in_representations: [MeowNx.permutation_representation()],
+      impl: fn population, _ctx ->
+        Population.map_genomes(population, fn genomes ->
+          Permutation.mutation_inversion(genomes, opts)
+        end)
+      end
+    }
+  end
+
+  @doc """
+  Builds a swap mutation operation.
+
+  See `MeowNx.Permutation.mutation_swap/2` for more details.
+  """
+  @doc type: :mutation
+  @spec mutation_swap(float()) :: Op.t()
+  def mutation_swap(probability) do
+    opts = [probability: probability]
+
+    %Op{
+      name: "[Nx] Mutation: swap",
+      requires_fitness: false,
+      invalidates_fitness: true,
+      in_representations: [MeowNx.permutation_representation()],
+      impl: fn population, _ctx ->
+        Population.map_genomes(population, fn genomes ->
+          Permutation.mutation_swap(genomes, opts)
+        end)
+      end
+    }
+  end
+end

--- a/lib/meow_nx/permutation.ex
+++ b/lib/meow_nx/permutation.ex
@@ -1,0 +1,396 @@
+defmodule MeowNx.Permutation do
+  @moduledoc """
+  Numerical implementations of common evolutionary operations for
+  permutations without repetitions.
+  """
+
+  import Nx.Defn
+
+  alias MeowNx.Utils
+
+  # Each individual represented as a permutation of numbers starting
+  # at 0. When applying evolutionary operations it is critical that
+  # the resulting individuals are valid permuations, specifically,
+  # that we don't introduce duplicate numbers.
+  #
+  # The primary idea driving the implementations is that we can work
+  # on positions (indices), rather than the elements. Let's consider
+  # the following permutation of elements
+  #
+  #     2 0 3 1
+  #
+  # In this sequence, the index is the position and the value is the
+  # element at that position. We can view this as `position -> element`
+  # mapping
+  #
+  #     0 -> 2, 1 -> 0, 2 -> 3, 3 -> 1
+  #
+  # Since both positions and elements use the same unique numbers, we
+  # can cleanly reverse the mapping to `element -> position`, which
+  # is represented by the following sequence
+  #
+  #     1 3 0 2
+  #
+  # In this sequence, the index is the element and the value is its
+  # position in the original permutation.
+  #
+  # Note that translating between these representations is equivalent
+  # to argsort, though it can be done in linear time.
+  #
+  # ## One-point crossover
+  #
+  # To give a better idea of how the positions domain works, let's
+  # consider one-point crossover (adopted for permutations). We have
+  # the following pair of individuals:
+  #
+  #     2 0 3 1
+  #     1 2 3 0
+  #
+  # For this example we can assume the cut is in the middle. This
+  # means that we want to copy the first two elements from parents to
+  # offsprings, then we want to add the remaining elements following
+  # their order in the other parent.
+  #
+  # In the first step, we translate permutations to positions, as
+  # outlined in the previous section
+  #
+  #     1 3 0 2
+  #     3 0 1 2
+  #
+  # Now, remember that indices correspond to permutation elements. We
+  # want to keep first two elements unchanged, so we fix the first
+  # two positions, that is 0 and 1
+  #
+  #     1 * 0 *
+  #     * 0 1 *
+  #
+  # Next, for the remaining elements, we take their positions from
+  # the other parent. We increase those positions by 10, so that all
+  # values are unique, and the relative order is preserved
+  #
+  #      1 10  0 12
+  #     11  0  1 12
+  #
+  # This gives us improper positions, which means that the values are
+  # not valid positions, but the relative order is fine. Fortunately,
+  # we can convert improper positions back to elements using argsort
+  #
+  #     2 0 1 3
+  #     1 2 0 3
+  #
+  # This is where the magic happens. Since we increased the positions
+  # of elements taken from the other parent, those elements end up at
+  # the end (in the correct order), while the first two elements stay
+  # untouched.
+  #
+  # In the above operation there are two blocks, left and right. The
+  # important characteristic is that the elements within the left
+  # block are kept as is, while the remaining ones are reordered to
+  # match the other parent. This behaviour can be used to implement
+  # other crossover types. We would first move the elements we want
+  # to fix to the first block and the rest to the second block, then
+  # we would apply this operation, finally we would move the elements
+  # back by inverting the first step.
+
+  @doc """
+  Generates a population, where each genome is a random permutation
+  of numbers from `0` to `length - 1`.
+
+  ## Options
+
+    * `:n` - the number of individuals to generate. Required.
+
+    * `:length` - the length of a single genome. Required.
+  """
+  defn init_random(opts \\ []) do
+    opts = keyword!(opts, [:n, :length])
+    n = opts[:n]
+    length = opts[:length]
+
+    Nx.random_uniform({n, length})
+    |> Nx.argsort(axis: 1)
+    |> Nx.as_type({:u, 16})
+  end
+
+  @doc """
+  Performs single-point crossover adopted for permutations.
+
+  For parent genomes $x$ and $y$, this operation chooses a random
+  split point. All genes $x_i$, $y_i$ until that split point are
+  copied to the offsprings. Then, the missing genes are copied from
+  the other parent keeping their relative order.
+
+  ## References
+
+    * [Genetic Algorithms for Shop Scheduling Problems: A Survey](https://www.researchgate.net/publication/230724890_GENETIC_ALGORITHMS_FOR_SHOP_SCHEDULING_PROBLEMS_A_SURVEY), Fig. 8.
+  """
+  defn crossover_single_point(genomes) do
+    {n, length} = Nx.shape(genomes)
+    half_n = transform(n, &div(&1, 2))
+
+    positions = permutations_to_positions(genomes)
+    split_position = Nx.random_uniform({half_n, 1}, 1, length) |> Utils.duplicate_rows()
+
+    positions_single_point(positions, positions, split_position)
+  end
+
+  @doc """
+  Performs order crossover (OX).
+
+  For parent genomes $x$ and $y$, this operation chooses two random
+  split points. All genes $x_i$, $y_i$ between those split points are
+  copied to the offsprings. Then, the missing genes are copied from
+  the other parent keeping their relative order, going from the second
+  split point.
+
+  Note that OX is designed for cyclic permutations, so for non-cyclic
+  permutations LOX (`crossover_linear_order/1`) is a better fit.
+
+  ## References
+
+    * [Genetic Algorithms for Shop Scheduling Problems: A Survey](https://www.researchgate.net/publication/230724890_GENETIC_ALGORITHMS_FOR_SHOP_SCHEDULING_PROBLEMS_A_SURVEY), Fig. 9.
+  """
+  defn crossover_order(genomes) do
+    {offset, block_length} = random_genome_blocks(genomes, paired: true)
+
+    positions = permutations_to_positions(genomes)
+    shifted_positions = shift_positions(positions, -offset)
+
+    positions_single_point(
+      shifted_positions,
+      # For the remaining elments we want to inherit the relative
+      # order from the other parent, but starting from the second
+      # crossover point. To do so we shift the parent elements
+      # further to the left by the block length
+      shift_positions(shifted_positions, -block_length),
+      block_length
+    )
+    |> Utils.shift(Nx.reshape(offset, {:auto}), axis: 1)
+  end
+
+  @doc """
+  Performs position based crossover (PBX).
+
+  This operation chooses a number of random positions and copies genes
+  at those positions to the offsprings. Then, the missing genes are
+  copied from the other parent keeping their relative order.
+
+  Order based crossover (OBX) is another common operation, however it
+  is effectively the same as PBX.
+
+  ## References
+
+    * [Genetic Algorithms for Shop Scheduling Problems: A Survey](https://www.researchgate.net/publication/230724890_GENETIC_ALGORITHMS_FOR_SHOP_SCHEDULING_PROBLEMS_A_SURVEY), Fig. 12.
+    * [Crossover operators for permutations equivalence between position and order-based crossover](https://www.researchgate.net/publication/220245134_Crossover_operators_for_permutations_equivalence_between_position_and_order-based_crossover)
+  """
+  defn crossover_position_based(genomes) do
+    {n, length} = Nx.shape(genomes)
+    half_n = transform(n, &div(&1, 2))
+
+    fix_position? = Nx.random_uniform({half_n, length}, 0, 2) |> Utils.duplicate_rows()
+    split_position = Nx.sum(fix_position?, axes: [1], keep_axes: true)
+
+    mapping =
+      fix_position?
+      |> Nx.iota(axis: 1)
+      |> Nx.add(Nx.negate(fix_position?) * length)
+      |> relative_positions_to_permutations()
+
+    mapped_single_point(genomes, mapping, split_position)
+  end
+
+  @doc """
+  Performs linear order crossover (LOX).
+
+  This is a modified version of `crossover_order/1`. Similarly, two
+  split points are choosen and genes between those points are copied
+  directly to the offspring. Then, the missing genes are copied from
+  the other parent starting from the first position (as opposed to OX,
+  where we start from the second split point).
+
+  Note that that this operation was later reintroduced under the name
+  non-wrapping order crossover (NWOX).
+
+  ## References
+
+    * [Genetic Algorithms for Shop Scheduling Problems: A Survey](https://www.researchgate.net/publication/230724890_GENETIC_ALGORITHMS_FOR_SHOP_SCHEDULING_PROBLEMS_A_SURVEY), Fig. 10.
+    * [Non-Wrapping Order Crossover: An Order Preserving Crossover Operator that Respects Absolute Position](https://www.researchgate.net/publication/220739642_Non-wrapping_order_crossover_An_order_preserving_crossover_operator_that_respects_absolute_position)
+  """
+  defn crossover_linear_order(genomes) do
+    {offset, block_length} = random_genome_blocks(genomes, paired: true)
+
+    # A random block divides genome into three parts A B C (where B
+    # is the random block). We want to rearrange the genes into parts
+    # B A C, so that we can fix genes in B. We do this rearrangement
+    # by generating an index mapping
+
+    idx = Nx.iota(genomes, axis: 1)
+
+    mapping =
+      idx + (idx < block_length) * offset -
+        (block_length <= idx and idx < offset + block_length) * block_length
+
+    mapped_single_point(genomes, mapping, block_length)
+  end
+
+  @doc """
+  Performs inversion mutation.
+
+  This operation chooses two random points in the genome and reverses
+  all elements between these points.
+
+  ## Options
+
+    * `:probability` - probability of an individual being mutated.
+      Required
+
+  ## References
+
+    * [Genetic Algorithms for Shop Scheduling Problems: A Survey](https://www.researchgate.net/publication/230724890_GENETIC_ALGORITHMS_FOR_SHOP_SCHEDULING_PROBLEMS_A_SURVEY), Fig. 15.
+  """
+  defn mutation_inversion(genomes, opts \\ []) do
+    opts = keyword!(opts, [:probability])
+    probability = opts[:probability]
+
+    {offset, block_length} = random_genome_blocks(genomes, paired: false)
+
+    a = offset
+    b = offset + block_length - 1
+
+    idx = Nx.iota(genomes, axis: 1)
+    block? = a <= idx and idx <= b
+    mapping = Nx.select(block?, b - (idx - a), idx)
+    mutated = Nx.take_along_axis(genomes, mapping, axis: 1)
+
+    incorporate_mutated(genomes, mutated, probability)
+  end
+
+  @doc """
+  Performs swap mutation.
+
+  This operation swaps two random elements in the genome.
+
+  Note that this operation is also referred to as exchange mutation
+  or interchange mutation.
+
+  ## Options
+
+    * `:probability` - probability of an individual being mutated.
+      Required
+
+  ## References
+
+    * [Genetic Algorithms for Shop Scheduling Problems: A Survey](https://www.researchgate.net/publication/230724890_GENETIC_ALGORITHMS_FOR_SHOP_SCHEDULING_PROBLEMS_A_SURVEY), Fig. 14.
+  """
+  defn mutation_swap(genomes, opts \\ []) do
+    opts = keyword!(opts, [:probability])
+    probability = opts[:probability]
+
+    {n, length} = Nx.shape(genomes)
+
+    # Randomly generate two distinct positions
+    swap_position1 = Nx.random_uniform({n}, 0, length)
+    swap_position2 = Nx.random_uniform({n}, 0, length - 1)
+    swap_position2 = swap_position2 + (swap_position2 >= swap_position1)
+    swap_positions = Nx.stack([swap_position1, swap_position2], axis: -1)
+
+    indices = Nx.stack([Nx.iota({n, 2}, axis: 0), swap_positions], axis: -1)
+    values = Nx.gather(genomes, indices)
+    swapped_values = Nx.reverse(values, axes: [1])
+    diff = swapped_values - values
+
+    mutated =
+      Nx.indexed_add(
+        genomes,
+        Nx.reshape(indices, {:auto, 2}),
+        Nx.reshape(diff, {:auto})
+      )
+
+    incorporate_mutated(genomes, mutated, probability)
+  end
+
+  defnp incorporate_mutated(genomes, mutated_genomes, probability) do
+    {n, length} = Nx.shape(genomes)
+
+    mutate? = Nx.random_uniform({n, 1}) |> Nx.less(probability)
+
+    mutate?
+    |> Nx.broadcast({n, length})
+    |> Nx.select(mutated_genomes, genomes)
+  end
+
+  defnp positions_single_point(positions, parent_positions, split_position) do
+    {_n, length} = Nx.shape(positions)
+
+    # For elements until the split point we keep the same positions.
+    # For the remaining elements we copy their positions from the
+    # other parent and increase them by `length`. This way when we
+    # do argsort, those elements end up at the end, but their relative
+    # order is preserved.
+    Nx.select(
+      positions < split_position,
+      parent_positions,
+      parent_positions |> MeowNx.Utils.swap_adjacent_rows() |> Nx.add(length)
+    )
+    |> relative_positions_to_permutations()
+  end
+
+  defnp mapped_single_point(genomes, mapping, split_position) do
+    reverse_mapping = permutations_to_positions(mapping)
+
+    mapped_genomes = Nx.take_along_axis(genomes, mapping, axis: 1)
+    mapped_positions = permutations_to_positions(mapped_genomes)
+
+    positions = permutations_to_positions(genomes)
+
+    # For the other parent we want to consider the original order
+    positions_single_point(mapped_positions, positions, split_position)
+    |> Nx.take_along_axis(reverse_mapping, axis: 1)
+  end
+
+  defnp random_genome_blocks(genomes, opts \\ []) do
+    opts = keyword!(opts, paired: false)
+
+    transform({genomes, opts[:paired]}, fn
+      {genomes, false} ->
+        {n, length} = Nx.shape(genomes)
+        random_blocks(n: n, length: length)
+
+      {genomes, true} ->
+        {n, length} = Nx.shape(genomes)
+        {offset, block_length} = random_blocks(n: div(n, 2), length: length)
+        {Utils.duplicate_rows(offset), Utils.duplicate_rows(block_length)}
+    end)
+  end
+
+  defnp random_blocks(opts \\ []) do
+    n = opts[:n]
+    length = opts[:length]
+
+    idx1 = Nx.random_uniform({n, 1}, 0, length)
+    idx2 = Nx.random_uniform({n, 1}, 0, length)
+
+    a = Nx.min(idx1, idx2)
+    b = Nx.max(idx1, idx2)
+
+    offset = a
+    block_length = b - a + 1
+
+    {offset, block_length}
+  end
+
+  defnp shift_positions(positions, offset) do
+    {_, length} = Nx.shape(positions)
+    Nx.remainder(positions + offset + length, length)
+  end
+
+  defnp permutations_to_positions(permutations) do
+    Utils.permutation_argsort(permutations, axis: 1)
+  end
+
+  defnp relative_positions_to_permutations(relative_positions) do
+    relative_positions
+    |> Nx.argsort(axis: 1)
+    |> Nx.as_type(Nx.type(relative_positions))
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -6,6 +6,6 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.15.2", "dc72dfe17eb240552857465cc00cce390960d9a0c055c4ccd38b70629227e97c", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "fd23ae48d09b32eff49d4ced2b43c9f086d402ee4fd4fcb2d7fad97fa8823e75"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.0", "b44d75e2a6542dcb6acf5d71c32c74ca88960421b6874777f79153bbbbd7dccc", [:mix], [], "hexpm", "52b2871a7515a5ac49b00f214e4165a40724cf99798d8e4a65e4fd64ebd002c1"},
-  "nx": {:git, "https://github.com/elixir-nx/nx.git", "bdd14c4abf962caf21e68fa798dbf1063d8b450c", [branch: "main", sparse: "nx"]},
+  "nx": {:git, "https://github.com/elixir-nx/nx.git", "7ab4deebae9d7860ec75ce4c7fb35369272e3214", [branch: "main", sparse: "nx"]},
   "vega_lite": {:hex, :vega_lite, "0.1.3", "38eeb47d66a881086d0e596b592e3aa75084115d00315c387716c131684f3513", [:mix], [], "hexpm", "ea6e8f951944144b15f26d0b33c255c2b1b553a65e3fffcd91784bfdc56ebb54"},
 }


### PR DESCRIPTION
This adds a new representation - permutation without repetitions, together with several crossover and mutation operations. To validate the idea it also includes a TSP example. For now I put the new operations in a new `MeowNx.Permutation` module and their Meow definitions in `MeowNx.Ops.Permutation`.